### PR TITLE
Fix: Use muted line color for StepIndicator and CommandSeparator

### DIFF
--- a/src/components/Command/src/CommandSeparator.tsx
+++ b/src/components/Command/src/CommandSeparator.tsx
@@ -9,7 +9,7 @@ const CommandSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
     ref={ref}
-    className={cn('bg-border -mx-1 h-px', className)}
+    className={cn('-mx-1 h-px bg-muted', className)}
     {...props}
   />
 ));

--- a/src/components/StepIndicator/src/StepIndicator.tsx
+++ b/src/components/StepIndicator/src/StepIndicator.tsx
@@ -117,7 +117,7 @@ const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
               {index < steps.length - 1 ? (
                 <div
                   className={cn(
-                    'bg-border absolute',
+                    'absolute bg-muted',
                     orientation === 'vertical'
                       ? sizeStyles[size].connector.vertical
                       : sizeStyles[size].connector.horizontal,


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Use muted background color for lines in step indicator and command separator

### Testing

1. Run `npm run storybook`
2. Navigate to the StepIndicator
3. Compare with screenshots below

### Screenshots

#### After

![image](https://github.com/user-attachments/assets/c417351b-fe1a-4acb-b883-6fe4917ecaf8)

#### Before

![image](https://github.com/user-attachments/assets/94175997-3152-49f4-9d03-b2b3ae684a3e)