### PR TITLE
Fix: Popover arrow stroke color

### DIFF
--- a/src/components/Popover/src/Popover.tsx
+++ b/src/components/Popover/src/Popover.tsx
@@ -22,7 +22,7 @@ const PopoverContent = React.forwardRef<
     >
       {children}
       {hasArrow ? (
-        <PopoverArrow className="stroke-border fill-popover stroke-[1px]" width={11} height={5} />
+        <PopoverArrow className="fill-popover stroke-muted stroke-[1px]" width={15} height={7} />
       ) : null}
     </PopoverPrimitive.Content>
   </PopoverPrimitive.Portal>


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Use muted color for popover arrow stroke color

### Testing

1. Run `npm run storybook`
2. Navigate to the Popover
3. Compare with screenshots below

### Screenshots

#### After

![image](https://github.com/user-attachments/assets/1bef578d-8468-4d30-8654-67c3184482f2)

#### Before

![image](https://github.com/user-attachments/assets/9d684806-eba9-49de-bf3a-156722d552c0)
