### PR TITLE
Chore: StepIndicator CVA Refactor

### DIFF
--- a/src/components/StepIndicator/constants.ts
+++ b/src/components/StepIndicator/constants.ts
@@ -1,0 +1,104 @@
+import { cva } from 'class-variance-authority';
+
+export const stepIndicatorVariants = cva('flex', {
+  variants: {
+    orientation: {
+      horizontal: 'flex-row',
+      vertical: 'flex-col',
+    },
+    size: {
+      sm: 'gap-4',
+      default: 'gap-6',
+      lg: 'gap-8',
+    },
+  },
+  defaultVariants: {
+    orientation: 'horizontal',
+    size: 'default',
+  },
+});
+
+export const stepIndicatorCircleVariants = cva(
+  'relative z-10 flex items-center justify-center rounded-full border-[3px] bg-white font-bold',
+  {
+    variants: {
+      size: {
+        sm: 'h-6 w-6 text-xs',
+        default: 'h-8 w-8 text-sm',
+        lg: 'h-10 w-10 text-base',
+      },
+      status: {
+        default: 'border-muted text-muted-foreground',
+        current: 'border-primary-400 text-primary-400',
+        completed: 'border-primary-400 bg-primary-400 text-white',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+      status: 'default',
+    },
+  },
+);
+
+export const stepIndicatoConnectorVariants = cva('absolute bg-muted', {
+  variants: {
+    size: {
+      sm: '',
+      default: '',
+      lg: '',
+    },
+    orientation: {
+      horizontal: 'w-[calc(100%_-_1.5rem)]',
+      vertical: 'h-full',
+    },
+  },
+  compoundVariants: [
+    {
+      size: 'sm',
+      orientation: 'horizontal',
+      class: 'left-[calc(50%_+_1.25rem)] top-3 h-[2px]',
+    },
+    {
+      size: 'default',
+      orientation: 'horizontal',
+      class: 'left-[calc(50%_+_1.5rem)] top-[calc(1rem_-_1px)] h-[3px]',
+    },
+    {
+      size: 'lg',
+      orientation: 'horizontal',
+      class: 'left-[calc(50%_+_1.75rem)] top-[calc(1.25rem_-_1px)] h-[4px]',
+    },
+    {
+      size: 'sm',
+      orientation: 'vertical',
+      class: 'left-[0.6875rem] top-[1.25rem] w-0.5',
+    },
+    {
+      size: 'default',
+      orientation: 'vertical',
+      class: 'left-[0.9375rem] top-[1.75rem] w-[3px]',
+    },
+    {
+      size: 'lg',
+      orientation: 'vertical',
+      class: 'left-[1.125rem] top-[2.25rem] w-[4px]',
+    },
+  ],
+  defaultVariants: {
+    orientation: 'horizontal',
+    size: 'default',
+  },
+});
+
+export const stepIndicatorTextVariants = cva('font-medium', {
+  variants: {
+    size: {
+      sm: 'text-sm',
+      default: 'text-base',
+      lg: 'text-lg',
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+});

--- a/src/components/StepIndicator/src/StepIndicator.tsx
+++ b/src/components/StepIndicator/src/StepIndicator.tsx
@@ -1,62 +1,29 @@
 import { cn } from '@/lib/utils';
 import { Check } from 'lucide-react';
 import * as React from 'react';
+import {
+  stepIndicatoConnectorVariants,
+  stepIndicatorCircleVariants,
+  stepIndicatorTextVariants,
+  stepIndicatorVariants,
+} from '../constants';
 import { StepIndicatorProps } from '../types';
 
 const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
   ({ steps, currentStep, orientation = 'horizontal', size = 'default', className }, ref) => {
-    const sizeStyles = {
-      sm: {
-        container: 'gap-4',
-        circle: 'h-6 w-6 text-xs',
-        connector: {
-          horizontal: 'h-[2px] w-[calc(100%_-_1.5rem)] left-[calc(50%_+_1.25rem)] top-3',
-          vertical: 'h-full w-0.5 left-[0.6875rem] top-[1.25rem]',
-        },
-        text: 'text-sm',
-      },
-      default: {
-        container: 'gap-6',
-        circle: 'h-8 w-8 text-sm',
-        connector: {
-          horizontal:
-            'h-[3px] w-[calc(100%_-_1.5rem)] left-[calc(50%_+_1.5rem)] top-[calc(1rem_-_1px)]',
-          vertical: 'h-full w-[3px] left-[0.9375rem] top-[1.75rem]',
-        },
-        text: 'text-base',
-      },
-      lg: {
-        container: 'gap-8',
-        circle: 'h-10 w-10 text-base',
-        connector: {
-          horizontal:
-            'h-[4px] w-[calc(100%_-_1.5rem)] left-[calc(50%_+_1.75rem)] top-[calc(1.25rem_-_1px)]',
-          vertical: 'h-full w-[4px] left-[1.125rem] top-[2.25rem]',
-        },
-        text: 'text-lg',
-      },
-    };
-
     return (
-      <div
-        ref={ref}
-        className={cn(
-          'flex',
-          orientation === 'vertical' ? 'flex-col' : 'flex-row',
-          sizeStyles[size].container,
-          className,
-        )}
-      >
+      <div ref={ref} className={cn(stepIndicatorVariants({ orientation, size }), className)}>
         {steps.map((step, index) => {
           const isCompleted = index < currentStep;
           const isCurrent = index === currentStep;
+          const status = isCurrent ? 'current' : isCompleted ? 'completed' : 'default';
 
           return (
             <div
               key={step.id}
               className={cn(
-                'relative flex',
-                orientation === 'vertical' ? 'items-start' : 'flex-1 items-center justify-center',
+                'relative flex items-start',
+                orientation === 'horizontal' && 'flex-1 justify-center',
               )}
             >
               <div
@@ -66,17 +33,7 @@ const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
                 )}
               >
                 {/* Step circle */}
-                <div
-                  className={cn(
-                    'relative z-10 flex items-center justify-center rounded-full border-[3px] bg-white font-bold',
-                    sizeStyles[size].circle,
-                    isCompleted
-                      ? 'border-primary-400 bg-primary-400 text-white'
-                      : isCurrent
-                        ? 'border-primary-400 text-primary-400'
-                        : 'border-muted text-muted-foreground',
-                  )}
-                >
+                <div className={cn(stepIndicatorCircleVariants({ size, status }))}>
                   {isCompleted ? (
                     <Check className="h-4 w-4" strokeWidth={3} />
                   ) : (
@@ -93,8 +50,7 @@ const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
                 >
                   <span
                     className={cn(
-                      sizeStyles[size].text,
-                      'font-medium',
+                      stepIndicatorTextVariants({ size }),
                       isCurrent || isCompleted ? 'text-foreground' : 'text-muted-foreground',
                     )}
                   >
@@ -117,10 +73,7 @@ const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
               {index < steps.length - 1 ? (
                 <div
                   className={cn(
-                    'absolute bg-muted',
-                    orientation === 'vertical'
-                      ? sizeStyles[size].connector.vertical
-                      : sizeStyles[size].connector.horizontal,
+                    stepIndicatoConnectorVariants({ size, orientation }),
                     isCompleted && 'bg-primary-400',
                   )}
                 />

--- a/src/components/StepIndicator/src/StepIndicator.tsx
+++ b/src/components/StepIndicator/src/StepIndicator.tsx
@@ -9,6 +9,8 @@ import {
 } from '../constants';
 import { StepIndicatorProps } from '../types';
 
+type StepIndicatorStatus = 'default' | 'current' | 'completed';
+
 const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
   ({ steps, currentStep, orientation = 'horizontal', size = 'default', className }, ref) => {
     return (
@@ -16,7 +18,11 @@ const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
         {steps.map((step, index) => {
           const isCompleted = index < currentStep;
           const isCurrent = index === currentStep;
-          const status = isCurrent ? 'current' : isCompleted ? 'completed' : 'default';
+
+          // Determine the status of the step indicator
+          let status: StepIndicatorStatus = 'default';
+          if (isCurrent) status = 'current';
+          if (isCompleted) status = 'completed';
 
           return (
             <div
@@ -26,6 +32,7 @@ const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
                 orientation === 'horizontal' && 'flex-1 justify-center',
               )}
             >
+              {/* Step item */}
               <div
                 className={cn(
                   'relative flex',


### PR DESCRIPTION
### Type

- [X] Chore

### Description

- Refactored StepIndicator class variances using CVA
- Align top horizontal step indicator items

### Testing

1. Navigate to http://localhost:6006/?path=/docs/components-stepindicator--docs
2. Confirm styling looks the same on **main** and **chore/step-indicator-cva-refactor**
3. Horizontal step indicator items should now all align top in smaller layouts

### Screenshots

#### After

![image](https://github.com/user-attachments/assets/0b990147-2de5-4ebc-8dac-d03589cf107f)

#### Before

![image](https://github.com/user-attachments/assets/14d43cda-3191-45dd-a130-f2fddf2982be)
