### PR TITLE
Chore: Added Alert icon and content variants for minor spacing tweaks

### DIFF
--- a/src/components/Alert/constants.ts
+++ b/src/components/Alert/constants.ts
@@ -5,14 +5,14 @@ export const alertVariants = cva(
   {
     variants: {
       variant: {
-        success: 'border-success-400 bg-success-100 dark:bg-success-700 [&>svg]:text-success-400',
-        warning: 'border-warning-400 bg-warning-100 dark:bg-warning-700 [&>svg]:text-warning-400',
-        danger: 'border-danger-400 bg-danger-100 dark:bg-danger-700 [&>svg]:text-danger-400',
-        info: 'border-info-400 bg-info-100 dark:bg-info-700 [&>svg]:text-info-400',
+        success: 'border-success-400 bg-success-100 dark:bg-success-700',
+        warning: 'border-warning-400 bg-warning-100 dark:bg-warning-700',
+        danger: 'border-danger-400 bg-danger-100 dark:bg-danger-700',
+        info: 'border-info-400 bg-info-100 dark:bg-info-700',
       },
       size: {
-        sm: 'px-3 py-2 text-sm [&>svg]:mr-2 [&>svg]:h-5 [&>svg]:w-5',
-        default: 'px-4 py-4 text-base [&>svg]:mr-3 [&>svg]:h-8 [&>svg]:w-8',
+        sm: 'px-3 py-2 text-sm',
+        default: 'px-4 py-4 text-base',
       },
     },
     defaultVariants: {
@@ -21,14 +21,67 @@ export const alertVariants = cva(
   },
 );
 
+export const alertIconVariants = cva('', {
+  variants: {
+    size: {
+      sm: 'mr-2 [&>svg]:h-5 [&>svg]:w-5',
+      default: 'mr-3 [&>svg]:h-8 [&>svg]:w-8',
+    },
+    variant: {
+      success: 'text-success-400',
+      warning: 'text-warning-400',
+      danger: 'text-danger-400',
+      info: 'text-info-400',
+    },
+    hasHeading: {
+      true: '',
+      false: '',
+    },
+  },
+  compoundVariants: [
+    {
+      size: 'sm',
+      hasHeading: true,
+      class: 'mt-0.5',
+    },
+    {
+      size: 'default',
+      hasHeading: true,
+      class: '-mt-0.5',
+    },
+  ],
+  defaultVariants: {
+    size: 'default',
+  },
+});
+
+export const alertContentVariants = cva('flex-1', {
+  variants: {
+    size: {
+      sm: '',
+      default: '',
+    },
+    hasIcon: {
+      true: '',
+      false: '',
+    },
+    hasHeading: {
+      true: '',
+      false: '',
+    },
+  },
+  compoundVariants: [
+    {
+      size: 'default',
+      hasIcon: true,
+      hasHeading: false,
+      class: 'pt-1',
+    },
+  ],
+});
+
 export const alertHeadingVariants = cva('mb-1 font-bold text-base-700 dark:text-base-100', {
   variants: {
-    variant: {
-      success: '',
-      warning: '',
-      danger: '',
-      info: '',
-    },
     size: {
       sm: 'text-base',
       default: 'text-lg',

--- a/src/components/Alert/src/Alert.tsx
+++ b/src/components/Alert/src/Alert.tsx
@@ -1,7 +1,12 @@
 import { cn } from '@/lib/utils';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info } from 'lucide-react';
 import * as React from 'react';
-import { alertHeadingVariants, alertVariants } from '../constants';
+import {
+  alertContentVariants,
+  alertHeadingVariants,
+  alertIconVariants,
+  alertVariants,
+} from '../constants';
 import { AlertProps } from '../types';
 
 const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
@@ -28,12 +33,14 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
 
     return (
       <div ref={ref} className={cn(alertVariants({ variant, size }), className)} {...props}>
-        {hasIcon ? icons[variant] : null}
-        <div className="flex-1">
+        {hasIcon ? (
+          <span className={cn(alertIconVariants({ variant, size, hasHeading: !!heading }))}>
+            {icons[variant]}
+          </span>
+        ) : null}
+        <div className={cn(alertContentVariants({ size, hasIcon, hasHeading: !!heading }))}>
           {heading ? (
-            <HeadingTag className={cn(alertHeadingVariants({ variant, size }))}>
-              {heading}
-            </HeadingTag>
+            <HeadingTag className={cn(alertHeadingVariants({ size }))}>{heading}</HeadingTag>
           ) : null}
           {children}
         </div>


### PR DESCRIPTION
### Type

- [X] Chore

### Description

- Some of the Alert combinations of size/headings looked slightly misaligned since the flex container was aligning items top
- Adding icon and content variants to the Alert allows us to address these issues

### Testing

1. Navigate to http://localhost:6006/?path=/docs/components-alert--docs
2. Compare before/after with main branch (see screenshots below)

### Screenshots

#### After

![image](https://github.com/user-attachments/assets/b4f2aaa6-a5ad-4cfc-83a8-b37c56257b93)

![image](https://github.com/user-attachments/assets/a20a8cb8-ff33-4259-8726-61a31ea8bb06)

#### Before

![image](https://github.com/user-attachments/assets/a0ee93ac-5594-49e5-919e-0ce8240008d6)

![image](https://github.com/user-attachments/assets/d11a681c-1f13-4da1-9def-c0ca3fa9ea88)
