### PR TITLE
Fix: Don't include border color with selected preflight styles

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,11 +4,13 @@
 
 /* these styles are pulled from Tailwind's Preflight and are still required */
 
-*,
-::before,
-::after {
-  box-sizing: border-box;
-  border-width: 0;
-  border-style: solid;
-  border-color: #e5e7eb;
+@tailwind base;
+
+@layer base {
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+    border: 0 solid;
+  }
 }


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Include border color in the mini preflight was causing CSS specificity issues for consumers
- This PR removes the inclusion of the border color in the selected preflight
- Going forward, as per Tailwind v4, `currentColor` will be used when the `border` class is added