### PR TITLE
Feature: FormItem IDs

### DIFF
--- a/src/components/FormItem/src/FormItem.tsx
+++ b/src/components/FormItem/src/FormItem.tsx
@@ -6,9 +6,31 @@ import { FormItemProps } from '../types';
 
 const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
   (
-    { label, labelSlot, hintText, errorText, className, children, isRequired = false, ...props },
+    {
+      label,
+      labelSlot,
+      hintText,
+      errorText,
+      className,
+      children,
+      elementId,
+      isRequired = false,
+      ...props
+    },
     ref,
   ) => {
+    const childId = elementId ?? children.props?.id;
+
+    if (!!childId === false) {
+      throw new Error(
+        'FormItem must have either an `elementId` prop or an `id` attribute specified on the child element',
+      );
+    }
+
+    const labelId = `form-item-${childId}-label`;
+    const hintId = `form-item-${childId}-hint`;
+    const errorId = `form-item-${childId}-error`;
+
     return (
       <div
         ref={ref}
@@ -20,7 +42,7 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
           {label ? (
             <div className="flex items-center">
               {typeof label === 'string' ? (
-                <Label className="font-bold">
+                <Label className="font-bold" id={labelId} htmlFor={childId}>
                   {label}
                   {isRequired ? <span className="ml-0.5 text-destructive">*</span> : null}
                 </Label>
@@ -30,10 +52,18 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
               {labelSlot ? <div className="ml-2">{labelSlot}</div> : null}
             </div>
           ) : null}
-          {hintText ? <p className={styles.text.hint}>{hintText}</p> : null}
+          {hintText ? (
+            <p className={styles.text.hint} id={hintId}>
+              {hintText}
+            </p>
+          ) : null}
         </div>
         {children}
-        {errorText ? <p className={styles.text.error}>{errorText}</p> : null}
+        {errorText ? (
+          <p className={styles.text.error} id={errorId}>
+            {errorText}
+          </p>
+        ) : null}
       </div>
     );
   },

--- a/src/components/FormItem/types.ts
+++ b/src/components/FormItem/types.ts
@@ -1,12 +1,36 @@
 import { ReactElement, ReactNode } from 'react';
 
 export interface FormItemProps {
+  /**
+   * The label for the form item. If a string is provided, it will be wrapped in a `<Label>` component. If a ReactNode is provided, it will be rendered as-is.
+   */
   label?: ReactNode;
+  /**
+   * An optional slot to display next to the label, such as an info icon with a tooltip or popover.
+   */
   labelSlot?: ReactNode;
+  /**
+   * Hint text to display below the label and above the form element.
+   */
   hintText?: string;
+  /**
+   * Error text to display below the form element. If provided, the form item will be styled to indicate an error.
+   */
   errorText?: string;
+  /**
+   * Additional classes to apply to the form item container.
+   */
   className?: string;
-  children: ReactElement;
+  /**
+   * The ID of the form element associated with this form item. This ID will be also be used to generate the label, hint, and error IDs for accessibility. If not provided, the ID of the child element will be used if available.
+   */
   elementId?: string;
+  /**
+   * The form element associated with this form item, such as an input or select.
+   */
+  children: ReactElement;
+  /**
+   * Whether the form item is required. If true, an asterisk (*) will be displayed next to the label.
+   */
   isRequired?: boolean;
 }

--- a/src/components/FormItem/types.ts
+++ b/src/components/FormItem/types.ts
@@ -22,7 +22,7 @@ export interface FormItemProps {
    */
   className?: string;
   /**
-   * The ID of the form element associated with this form item. This ID will be also be used to generate the label, hint, and error IDs for accessibility. If not provided, the ID of the child element will be used if available.
+   * The ID used to generate the label, hint, and error IDs for accessibility. If not provided, the ID of the top-level child element will be used if available. This ID must be unique on the page and must be used as the `id` attribute of the child form element so that it can be assocated with the label.
    */
   elementId?: string;
   /**

--- a/src/components/FormItem/types.ts
+++ b/src/components/FormItem/types.ts
@@ -1,11 +1,12 @@
-import { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 export interface FormItemProps {
   label?: ReactNode;
   labelSlot?: ReactNode;
-  hintText?: ReactNode;
-  errorText?: ReactNode;
+  hintText?: string;
+  errorText?: string;
   className?: string;
-  children: ReactNode;
+  children: ReactElement;
+  elementId?: string;
   isRequired?: boolean;
 }


### PR DESCRIPTION
### Type

- [X] Feature

### Description

- To help with A11y, we need to provide a way to generate the ID for label, hint and error elements in the FormItem
- We will allow either an `elementId` to be provided as a prop or pull the ID from the top-level child element