### PR TITLE
Fix: Disabled props precedence in Switch component

### DIFF
--- a/src/components/Switch/src/Switch.tsx
+++ b/src/components/Switch/src/Switch.tsx
@@ -40,8 +40,8 @@ const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, 
           )}
           checked={isChecked}
           aria-label={ariaLabel}
-          {...disabledProps}
           {...props}
+          {...disabledProps}
           ref={ref}
           id={id}
         >


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Override `props` that are passed in with `disabledProps` in the Switch component