### PR TITLE
Feature: Allow month and year picker in the Calendar component

### DIFF
--- a/src/components/Calendar/src/Calendar.tsx
+++ b/src/components/Calendar/src/Calendar.tsx
@@ -1,23 +1,117 @@
+import { Button } from '@/components/Button';
 import { buttonVariants } from '@/components/Button/constants';
 import { cn } from '@/lib/utils';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { DayPicker } from 'react-day-picker';
+import { useState } from 'react';
+import { ChevronProps, DayPicker, MonthCaptionProps } from 'react-day-picker';
 import { CalendarProps } from '../types';
+import { CalendarMonthPicker } from './CalendarMonthPicker';
+import { CalendarYearPicker } from './CalendarYearPicker';
 
 function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+  const [actionState, setActionState] = useState<'month' | 'year' | 'default'>('default');
+  const [activeMonth, setActiveMonth] = useState<Date | undefined>(undefined);
+
   const navHeight = 'h-7 md:h-9';
   const navButton = 'w-7 px-0 py-0 focus:ring-2 focus:ring-offset-0 md:w-9';
   const cellWidth = 'w-9 md:w-10 lg:w-11 px-0';
   const cellHeight = 'h-9 md:h-10 lg:h-11 py-0';
 
+  const Chevron = (props: ChevronProps) => {
+    const { orientation } = props;
+    if (orientation === 'left') return <ChevronLeft {...props} />;
+    return <ChevronRight {...props} />;
+  };
+
+  const MonthCaption = (props: MonthCaptionProps) => {
+    const { calendarMonth } = props;
+    return (
+      <div
+        className={cn(
+          navHeight,
+          'relative mx-12 flex items-center justify-center text-sm font-medium',
+        )}
+      >
+        <Button
+          variant="ghost"
+          size="sm"
+          className="px-1.5 focus:ring-2 focus:ring-offset-0"
+          onClick={() => setActionState('month')}
+        >
+          {calendarMonth.date.toLocaleString('default', { month: 'long' })}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="px-1.5 focus:ring-2 focus:ring-offset-0"
+          onClick={() => setActionState('year')}
+        >
+          {calendarMonth.date.getFullYear()}
+        </Button>
+      </div>
+    );
+  };
+
+  const MonthGrid = () => {
+    if (actionState === 'month')
+      return (
+        <CalendarMonthPicker
+          onSelect={month => {
+            const newMonth = activeMonth ? new Date(activeMonth) : new Date();
+            newMonth.setMonth(month);
+            setActiveMonth(newMonth);
+            setActionState('default');
+          }}
+        />
+      );
+    if (actionState === 'year')
+      return (
+        <CalendarYearPicker
+          onSelect={year => {
+            const newYear = activeMonth ? new Date(activeMonth) : new Date();
+            newYear.setFullYear(year);
+            setActiveMonth(newYear);
+            setActionState('default');
+          }}
+        />
+      );
+
+    // default view showing normal month grid; handled by 'getComponents' function
+    return <></>;
+  };
+
+  const getComponents = () => {
+    if (actionState === 'default') {
+      return { Chevron, MonthCaption };
+    }
+
+    return {
+      Chevron,
+      MonthCaption,
+      MonthGrid,
+    };
+  };
+
+  const defaultMonth =
+    props?.defaultMonth ??
+    activeMonth ??
+    (props?.mode === 'single' ? props?.selected : new Date()) ??
+    new Date();
+
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn('px-3 py-3', className)}
+      defaultMonth={defaultMonth}
+      month={activeMonth}
+      onMonthChange={setActiveMonth}
+      className={cn('min-w-80 px-3 py-3', className)}
       classNames={{
         months: 'flex flex-col gap-4 sm:flex-row',
-        month: 'space-y-4',
-        month_caption: cn(navHeight, 'flex items-center justify-center text-sm font-medium'),
+        month: 'w-full space-y-4',
+        month_caption: cn(
+          navHeight,
+          'relative flex items-center justify-center text-sm font-medium',
+        ),
         nav: 'absolute left-4 right-4 flex items-center justify-between',
         button_previous: cn(buttonVariants({ variant: 'ghost' }), navHeight, navButton),
         button_next: cn(buttonVariants({ variant: 'ghost' }), navHeight, navButton),
@@ -51,16 +145,11 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         hidden: 'invisible',
         ...classNames,
       }}
-      components={{
-        Chevron: props => {
-          if (props.orientation === 'left') return <ChevronLeft {...props} />;
-          return <ChevronRight {...props} />;
-        },
-      }}
+      components={getComponents()}
       {...props}
+      disableNavigation={actionState !== 'default'}
     />
   );
 }
-Calendar.displayName = 'Calendar';
 
 export { Calendar };

--- a/src/components/Calendar/src/Calendar.tsx
+++ b/src/components/Calendar/src/Calendar.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/Button';
 import { buttonVariants } from '@/components/Button/constants';
 import { cn } from '@/lib/utils';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ChevronProps, DayPicker, MonthCaptionProps } from 'react-day-picker';
 import { CalendarProps } from '../types';
 import { CalendarMonthPicker } from './CalendarMonthPicker';
@@ -11,6 +11,8 @@ import { CalendarYearPicker } from './CalendarYearPicker';
 function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
   const [actionState, setActionState] = useState<'month' | 'year' | 'default'>('default');
   const [activeMonth, setActiveMonth] = useState<Date | undefined>(undefined);
+  const monthButtonRef = useRef<HTMLButtonElement>(null);
+  const yearButtonRef = useRef<HTMLButtonElement>(null);
 
   const navHeight = 'h-7 md:h-9';
   const navButton = 'w-7 px-0 py-0 focus:ring-2 focus:ring-offset-0 md:w-9';
@@ -33,6 +35,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         )}
       >
         <Button
+          ref={monthButtonRef}
           variant="ghost"
           size="sm"
           className="px-1.5 focus:ring-2 focus:ring-offset-0"
@@ -43,6 +46,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         <Button
           variant="ghost"
           size="sm"
+          ref={yearButtonRef}
           className="px-1.5 focus:ring-2 focus:ring-offset-0"
           onClick={() => setActionState('year')}
         >
@@ -61,6 +65,10 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
             newMonth.setMonth(month);
             setActiveMonth(newMonth);
             setActionState('default');
+            // Focus the month button after selection
+            setTimeout(() => {
+              monthButtonRef.current?.focus();
+            }, 0);
           }}
         />
       );
@@ -72,6 +80,10 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
             newYear.setFullYear(year);
             setActiveMonth(newYear);
             setActionState('default');
+            // Focus the month button after selection
+            setTimeout(() => {
+              yearButtonRef.current?.focus();
+            }, 0);
           }}
         />
       );

--- a/src/components/Calendar/src/Calendar.tsx
+++ b/src/components/Calendar/src/Calendar.tsx
@@ -75,6 +75,8 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
     if (actionState === 'year')
       return (
         <CalendarYearPicker
+          startMonth={props.startMonth}
+          endMonth={props.endMonth}
           onSelect={year => {
             const newYear = activeMonth ? new Date(activeMonth) : new Date();
             newYear.setFullYear(year);
@@ -105,9 +107,9 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
   };
 
   const defaultMonth =
-    props?.defaultMonth ??
+    props.defaultMonth ??
     activeMonth ??
-    (props?.mode === 'single' ? props?.selected : new Date()) ??
+    (props.mode === 'single' ? props.selected : new Date()) ??
     new Date();
 
   return (

--- a/src/components/Calendar/src/CalendarMonthPicker.tsx
+++ b/src/components/Calendar/src/CalendarMonthPicker.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/Button';
 import { cn } from '@/lib';
+import { useEffect, useRef } from 'react';
 import { CalendarMonthPickerProps } from '../types';
 
 // Returns an array of month names, e.g. ['January', 'February', ...]
@@ -9,11 +10,20 @@ const getMonths = (): string[] =>
 
 export const CalendarMonthPicker = (props: CalendarMonthPickerProps) => {
   const { onSelect } = props;
+  const firstButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // Autofocus the first month button when the component mounts
+    if (firstButtonRef.current) {
+      firstButtonRef.current.focus();
+    }
+  }, []);
 
   return (
     <div className="-mx-1 -my-1 grid grid-cols-1 gap-1 px-1 py-1 md:grid-cols-2 lg:grid-cols-3">
       {getMonths().map((month, idx) => (
         <Button
+          ref={idx === 0 ? firstButtonRef : undefined}
           key={month}
           aria-label="Select calendar month"
           variant="ghost"

--- a/src/components/Calendar/src/CalendarMonthPicker.tsx
+++ b/src/components/Calendar/src/CalendarMonthPicker.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@/components/Button';
+import { cn } from '@/lib';
+import { CalendarMonthPickerProps } from '../types';
+
+// Returns an array of month names, e.g. ['January', 'February', ...]
+// Could use Intl.DateTimeFormat but this is simpler for now
+const getMonths = (): string[] =>
+  Array.from({ length: 12 }, (_, i) => new Date(0, i).toLocaleString('en-US', { month: 'long' }));
+
+export const CalendarMonthPicker = (props: CalendarMonthPickerProps) => {
+  const { onSelect } = props;
+
+  return (
+    <div className="-mx-1 -my-1 grid grid-cols-1 gap-1 px-1 py-1 md:grid-cols-2 lg:grid-cols-3">
+      {getMonths().map((month, idx) => (
+        <Button
+          key={month}
+          aria-label="Select calendar month"
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'relative min-h-10 w-full text-center text-sm font-normal focus-within:relative focus-within:z-20 focus:opacity-100 focus:ring-2 focus:ring-offset-0',
+          )}
+          onClick={() => {
+            onSelect?.(idx);
+          }}
+        >
+          {month}
+        </Button>
+      ))}
+    </div>
+  );
+};

--- a/src/components/Calendar/src/CalendarMonthPicker.tsx
+++ b/src/components/Calendar/src/CalendarMonthPicker.tsx
@@ -20,7 +20,7 @@ export const CalendarMonthPicker = (props: CalendarMonthPickerProps) => {
   }, []);
 
   return (
-    <div className="-mx-1 -my-1 grid grid-cols-1 gap-1 px-1 py-1 md:grid-cols-2 lg:grid-cols-3">
+    <div className="-mx-1 -my-1 grid max-h-72 min-w-80 grid-cols-1 gap-1 px-1 py-1 md:grid-cols-2 lg:grid-cols-3">
       {getMonths().map((month, idx) => (
         <Button
           ref={idx === 0 ? firstButtonRef : undefined}

--- a/src/components/Calendar/src/CalendarYearPicker.tsx
+++ b/src/components/Calendar/src/CalendarYearPicker.tsx
@@ -3,12 +3,22 @@ import { cn } from '@/lib';
 import { useEffect, useRef } from 'react';
 import { CalendarYearPickerProps } from '../types';
 
-// Returns an array of years, e.g. [2023, 2022, ..., 2000]
-const getYears = (qty = 24): number[] =>
-  Array.from({ length: qty }, (_, i) => new Date().getFullYear() - qty + 1 + i).reverse();
+// Returns an array of years based on `startMonth` and `endMonth` constraints
+const getYears = (startMonth?: Date, endMonth?: Date): number[] => {
+  const currentYear = new Date().getFullYear();
+  const startYear = startMonth ? startMonth.getFullYear() : currentYear - 23;
+  const endYear = endMonth ? endMonth.getFullYear() : currentYear;
+
+  const years: number[] = [];
+  for (let year = endYear; year >= startYear; year--) {
+    years.push(year);
+  }
+
+  return years;
+};
 
 export const CalendarYearPicker = (props: CalendarYearPickerProps) => {
-  const { onSelect } = props;
+  const { onSelect, startMonth, endMonth } = props;
   const firstButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
@@ -19,8 +29,8 @@ export const CalendarYearPicker = (props: CalendarYearPickerProps) => {
   }, []);
 
   return (
-    <div className="-mx-1 -my-1 grid max-h-72 w-full grid-cols-2 gap-1 overflow-y-auto px-1 py-1 md:grid-cols-3 lg:grid-cols-4">
-      {getYears().map((year, idx) => (
+    <div className="-mx-1 -my-1 grid max-h-72 min-w-80 gap-1 overflow-y-auto px-1 py-1 md:grid-cols-3 lg:grid-cols-4">
+      {getYears(startMonth, endMonth).map((year, idx) => (
         <Button
           ref={idx === 0 ? firstButtonRef : undefined}
           key={year}

--- a/src/components/Calendar/src/CalendarYearPicker.tsx
+++ b/src/components/Calendar/src/CalendarYearPicker.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components/Button';
+import { cn } from '@/lib';
+import { CalendarYearPickerProps } from '../types';
+
+// Returns an array of years, e.g. [2023, 2022, ..., 2000]
+const getYears = (qty = 24): number[] =>
+  Array.from({ length: qty }, (_, i) => new Date().getFullYear() - qty + 1 + i).reverse();
+
+export const CalendarYearPicker = (props: CalendarYearPickerProps) => {
+  const { onSelect } = props;
+
+  return (
+    <div className="-mx-1 -my-1 grid max-h-72 w-full grid-cols-2 gap-1 overflow-y-auto px-1 py-1 md:grid-cols-3 lg:grid-cols-4">
+      {getYears().map(year => (
+        <Button
+          key={year}
+          aria-label="Select calendar year"
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'relative min-h-10 w-full text-center text-sm font-normal focus-within:relative focus-within:z-20 focus:opacity-100 focus:ring-2 focus:ring-offset-0',
+          )}
+          onClick={() => {
+            onSelect?.(year);
+          }}
+        >
+          {year}
+        </Button>
+      ))}
+    </div>
+  );
+};

--- a/src/components/Calendar/src/CalendarYearPicker.tsx
+++ b/src/components/Calendar/src/CalendarYearPicker.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/Button';
 import { cn } from '@/lib';
+import { useEffect, useRef } from 'react';
 import { CalendarYearPickerProps } from '../types';
 
 // Returns an array of years, e.g. [2023, 2022, ..., 2000]
@@ -8,11 +9,20 @@ const getYears = (qty = 24): number[] =>
 
 export const CalendarYearPicker = (props: CalendarYearPickerProps) => {
   const { onSelect } = props;
+  const firstButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // Autofocus the first year button when the component mounts
+    if (firstButtonRef.current) {
+      firstButtonRef.current.focus();
+    }
+  }, []);
 
   return (
     <div className="-mx-1 -my-1 grid max-h-72 w-full grid-cols-2 gap-1 overflow-y-auto px-1 py-1 md:grid-cols-3 lg:grid-cols-4">
-      {getYears().map(year => (
+      {getYears().map((year, idx) => (
         <Button
+          ref={idx === 0 ? firstButtonRef : undefined}
           key={year}
           aria-label="Select calendar year"
           variant="ghost"

--- a/src/components/Calendar/types.ts
+++ b/src/components/Calendar/types.ts
@@ -7,6 +7,8 @@ export type CalendarMonthPickerProps = {
 
 export type CalendarYearPickerProps = {
   onSelect?: (year: number) => void;
+  startMonth?: Date;
+  endMonth?: Date;
 };
 
 export type CalendarProps = ComponentProps<typeof DayPicker>;

--- a/src/components/Calendar/types.ts
+++ b/src/components/Calendar/types.ts
@@ -1,4 +1,12 @@
 import { ComponentProps } from 'react';
 import { DayPicker } from 'react-day-picker';
 
+export type CalendarMonthPickerProps = {
+  onSelect?: (month: number) => void;
+};
+
+export type CalendarYearPickerProps = {
+  onSelect?: (year: number) => void;
+};
+
 export type CalendarProps = ComponentProps<typeof DayPicker>;

--- a/src/components/DatePicker/src/DatePicker.tsx
+++ b/src/components/DatePicker/src/DatePicker.tsx
@@ -12,6 +12,8 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
   (
     {
       value,
+      startMonth,
+      endMonth,
       onChange,
       placeholder = 'Pick a date',
       className,
@@ -49,7 +51,14 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto px-0 py-0" align="start" zIndex={resolvedZIndex}>
-          <Calendar mode="single" selected={value} onSelect={handleDateSelect} autoFocus />
+          <Calendar
+            mode="single"
+            startMonth={startMonth}
+            endMonth={endMonth}
+            selected={value}
+            onSelect={handleDateSelect}
+            autoFocus
+          />
         </PopoverContent>
       </Popover>
     );

--- a/src/components/DatePicker/stories/DatePicker.stories.tsx
+++ b/src/components/DatePicker/stories/DatePicker.stories.tsx
@@ -66,6 +66,20 @@ export const WithValue: Story = {
 };
 
 /**
+ * DatePicker with restricted start and end months.
+ * Shows how to limit the selectable date range within the specified months and years.
+ */
+export const WithStartAndEndMonth: Story = {
+  render: args => <DatePickerDemo {...args} />,
+  args: {
+    onChange: () => {},
+    placeholder: 'Pick a date',
+    startMonth: new Date(2020, 0),
+    endMonth: new Date(2025, 11),
+  },
+};
+
+/**
  * DatePicker with custom placeholder text.
  * Shows how to customize the placeholder message when no date is selected.
  */

--- a/src/components/DatePicker/types.ts
+++ b/src/components/DatePicker/types.ts
@@ -1,5 +1,7 @@
 export interface DatePickerProps {
   value?: Date;
+  startMonth?: Date;
+  endMonth?: Date;
   onChange: (date?: Date) => void;
   placeholder?: string;
   className?: string;


### PR DESCRIPTION
### Type

- [X] Feature

### Description

- Allow navigation across broad ranges of months and years with the CalendarMonthPicker and CalendarYearPicker, which are accessible by clicking on the month or year in the caption of the calendar 

### Testing

1. Navigate to http://localhost:6006/?path=/docs/components-datepicker--docs
2. Click on the month in the caption; you should be able to choose any month
3. Click on the year in the caption; you should be able to choose a year
4. Navigate to http://localhost:6006/?path=/docs/components-datepicker--docs#with-start-and-end-month
5. You should only be able to choose the years that fall within the `startMonth` and `endMonth` specified

### Screenshots

<img width="429" height="646" alt="image" src="https://github.com/user-attachments/assets/85007c27-1853-497c-8673-6c84ed931254" />

<img width="420" height="594" alt="image" src="https://github.com/user-attachments/assets/f4254832-3331-4abc-aa1a-423da8f13800" />

<img width="437" height="595" alt="image" src="https://github.com/user-attachments/assets/6ca98397-eb64-4bc2-86dc-c1f5206ba270" />