### PR TITLE
Fix: Always show focus regardless of mouse/keyboard activation

### DIFF
--- a/src/components/Accordion/constants.ts
+++ b/src/components/Accordion/constants.ts
@@ -4,7 +4,7 @@ import { cva } from 'class-variance-authority';
 
 export const accordionTriggerVariants = cva(
   cn(
-    styles.focusRingVisible,
+    styles.focusRing,
     'flex w-full flex-1 items-center px-4 py-[0.875rem] font-bold transition-all',
   ),
   {

--- a/src/components/Checkbox/src/CheckboxDefault.tsx
+++ b/src/components/Checkbox/src/CheckboxDefault.tsx
@@ -35,12 +35,7 @@ export const CheckboxDefault = React.forwardRef<
         <CheckboxPrimitive.Root
           ref={ref}
           checked={isChecked}
-          className={cn(
-            styles.focusRingVisible,
-            styles.focusRingVisibleSm,
-            checkboxClasses,
-            className,
-          )}
+          className={cn(styles.focusRing, styles.focusRingSm, checkboxClasses, className)}
           id={id}
           {...props}
           {...disabledProps}

--- a/src/components/Switch/src/Switch.tsx
+++ b/src/components/Switch/src/Switch.tsx
@@ -43,7 +43,7 @@ const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, 
         <SwitchPrimitives.Root
           aria-label={ariaLabel}
           checked={isChecked}
-          className={cn(styles.focusRingVisible, switchClasses, className)}
+          className={cn(styles.focusRing, switchClasses, className)}
           {...props}
           {...disabledProps}
           ref={ref}

--- a/src/components/Tabs/src/Tabs.tsx
+++ b/src/components/Tabs/src/Tabs.tsx
@@ -31,7 +31,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      styles.focusRingVisible,
+      styles.focusRing,
       `inline-flex items-center justify-center whitespace-nowrap rounded px-3 py-1.5 text-sm
       font-bold ring-offset-background transition-all hover:bg-primary-200 hover:text-primary
       disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50


### PR DESCRIPTION
### Type

- [X] Feature

### Description

- Differentiating between `focus` and `focus:visible` can be helpful for reducing the need to show focus states with mouse interaction, however it is problematic for much government which requires this for 508 compliance
- This PR switches all focus states back to being show regardless of keyboard or mouse interaction