### PR TITLE
Fix: Calendar 508/A11y compliance

### DIFF
--- a/src/components/Calendar/src/Calendar.tsx
+++ b/src/components/Calendar/src/Calendar.tsx
@@ -22,9 +22,12 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
   const outsideDayText =
     'text-[#767676] aria-selected:text-[#767676] dark:text-[#828282] dark:aria-selected:text-[#828282]';
 
-  // This is needed to ensure that the selected day's cell has rounded corners
   const selectedDay =
     props.mode === 'range' ? '' : '[&>button]:bg-primary [&>button]:text-primary-foreground';
+
+  // Blue outer border with white inset gap (508-friendly focus on day cells)
+  const dayButtonFocus =
+    'focus:ring-inset focus:ring-0 focus:ring-offset-2 focus:shadow-[inset_0_0_0_0_#ffffff,0_0_0_2px_#005ea2]';
 
   const components = useMemo(() => {
     const Chevron = createCalendarChevron(actionState);
@@ -83,8 +86,8 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
           cellWidth,
           cellHeight,
           `relative rounded-l-full rounded-r-full text-center text-sm font-normal
-          focus-within:relative focus-within:z-20 focus:opacity-100 focus:ring-2
-          focus:ring-offset-0`,
+          focus-within:relative focus-within:z-20 focus:opacity-100`,
+          dayButtonFocus,
         ),
         range_start: `rounded-l-full aria-selected:bg-accent [&>button]:bg-primary [&>button]:text-primary-foreground`,
         range_end: `rounded-r-full aria-selected:bg-accent [&>button]:bg-primary [&>button]:text-primary-foreground`,

--- a/src/components/Calendar/src/Calendar.tsx
+++ b/src/components/Calendar/src/Calendar.tsx
@@ -19,6 +19,10 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
   const cellWidth = 'w-9 md:w-10 lg:w-11 px-0';
   const cellHeight = 'h-9 md:h-10 lg:h-11 py-0';
 
+  // Lightest grays meeting WCAG AA (4.5:1) on popover backgrounds (#fff / #1a1a1a)
+  const outsideDayText =
+    'text-[#767676] aria-selected:text-[#767676] dark:text-[#828282] dark:aria-selected:text-[#828282]';
+
   const Chevron = (props: ChevronProps) => {
     if (actionState === 'month' || actionState === 'year') return <></>;
 
@@ -159,10 +163,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         button_next: cn(buttonVariants({ variant: 'ghost' }), navHeight, navButton),
         month_grid: 'w-full border-collapse space-y-1',
         weekdays: 'mb-1 flex',
-        weekday: cn(
-          cellWidth,
-          'rounded-l-full rounded-r-full text-sm font-normal text-muted-foreground',
-        ),
+        weekday: cn(cellWidth, 'text-sm font-medium text-popover-foreground'),
         week: 'mt-1 flex w-full',
         day: cn(cellWidth, cellHeight),
         day_button: cn(
@@ -182,7 +183,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
           props?.mode !== 'range' ? '[&>button]:bg-primary [&>button]:text-primary-foreground' : '',
         today:
           '[&>button]:rounded-l-full [&>button]:rounded-r-full [&>button]:bg-accent [&>button]:text-accent-foreground',
-        outside: 'day-outside text-muted-foreground opacity-50',
+        outside: cn('day-outside', outsideDayText),
         disabled: 'text-muted-foreground opacity-50',
         range_middle:
           'first:rounded-l-md last:rounded-r-md aria-selected:bg-accent aria-selected:text-accent-foreground',

--- a/src/components/Calendar/src/Calendar.tsx
+++ b/src/components/Calendar/src/Calendar.tsx
@@ -1,15 +1,14 @@
-import { Button } from '@/components/Button';
 import { buttonVariants } from '@/components/Button/constants';
 import { cn } from '@/lib/utils';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useRef, useState } from 'react';
-import { ChevronProps, DayPicker, MonthCaptionProps } from 'react-day-picker';
-import { CalendarProps } from '../types';
-import { CalendarMonthPicker } from './CalendarMonthPicker';
-import { CalendarYearPicker } from './CalendarYearPicker';
+import { useMemo, useRef, useState } from 'react';
+import { DayPicker } from 'react-day-picker';
+import { CalendarActionState, CalendarProps } from '../types';
+import { createCalendarChevron } from './CalendarChevron';
+import { createCalendarMonthCaption } from './CalendarMonthCaption';
+import { createCalendarMonthGrid } from './CalendarMonthGrid';
 
 function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
-  const [actionState, setActionState] = useState<'month' | 'year' | 'default'>('default');
+  const [actionState, setActionState] = useState<CalendarActionState>('default');
   const [activeMonth, setActiveMonth] = useState<Date | undefined>(undefined);
   const monthButtonRef = useRef<HTMLButtonElement>(null);
   const yearButtonRef = useRef<HTMLButtonElement>(null);
@@ -23,124 +22,37 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
   const outsideDayText =
     'text-[#767676] aria-selected:text-[#767676] dark:text-[#828282] dark:aria-selected:text-[#828282]';
 
-  const Chevron = (props: ChevronProps) => {
-    if (actionState === 'month' || actionState === 'year') return <></>;
+  // This is needed to ensure that the selected day's cell has rounded corners
+  const selectedDay =
+    props.mode === 'range' ? '' : '[&>button]:bg-primary [&>button]:text-primary-foreground';
 
-    const { orientation } = props;
-    if (orientation === 'left') return <ChevronLeft {...props} />;
-    return <ChevronRight {...props} />;
-  };
+  const components = useMemo(() => {
+    const Chevron = createCalendarChevron(actionState);
+    const MonthCaption = createCalendarMonthCaption({
+      actionState,
+      setActionState,
+      monthButtonRef,
+      yearButtonRef,
+      navHeight,
+    });
 
-  const MonthCaption = (props: MonthCaptionProps) => {
-    const { calendarMonth } = props;
-    return (
-      <div
-        className={cn(
-          navHeight,
-          'relative mx-12 flex items-center justify-center text-sm font-medium',
-        )}
-      >
-        <Button
-          ref={monthButtonRef}
-          aria-label="Select calendar month"
-          className="px-1.5 focus:ring-2 focus:ring-offset-0"
-          size="sm"
-          variant="ghost"
-          onClick={() => {
-            // if the user clicks the month that's already selected, just go back to default view
-            if (actionState === 'month') {
-              setActionState('default');
-
-              // focus the month button after selection
-              setTimeout(() => {
-                monthButtonRef.current?.focus();
-              }, 0);
-              return;
-            }
-
-            setActionState('month');
-          }}
-        >
-          {calendarMonth.date.toLocaleString('default', { month: 'long' })}
-        </Button>
-        <Button
-          ref={yearButtonRef}
-          aria-label="Select calendar year"
-          className="px-1.5 focus:ring-2 focus:ring-offset-0"
-          size="sm"
-          variant="ghost"
-          onClick={() => {
-            // if the user clicks the year that's already selected, just go back to default view
-            if (actionState === 'year') {
-              setActionState('default');
-
-              // focus the year button after selection
-              setTimeout(() => {
-                yearButtonRef.current?.focus();
-              }, 0);
-              return;
-            }
-
-            setActionState('year');
-          }}
-        >
-          {calendarMonth.date.getFullYear()}
-        </Button>
-      </div>
-    );
-  };
-
-  const MonthGrid = () => {
-    if (actionState === 'month')
-      return (
-        <CalendarMonthPicker
-          onSelect={month => {
-            // set the active month to the selected month, keeping the current year if possible
-            const newMonth = activeMonth ? new Date(activeMonth) : new Date();
-            newMonth.setMonth(month);
-            setActiveMonth(newMonth);
-            setActionState('default');
-            // focus the month button after selection
-            setTimeout(() => {
-              monthButtonRef.current?.focus();
-            }, 0);
-          }}
-        />
-      );
-    if (actionState === 'year')
-      return (
-        <CalendarYearPicker
-          endMonth={props.endMonth}
-          startMonth={props.startMonth}
-          onSelect={year => {
-            // set the active month to the selected year, keeping the current month if possible
-            const newYear = activeMonth ? new Date(activeMonth) : new Date();
-            newYear.setFullYear(year);
-            setActiveMonth(newYear);
-            setActionState('default');
-            // focus the month button after selection
-            setTimeout(() => {
-              yearButtonRef.current?.focus();
-            }, 0);
-          }}
-        />
-      );
-
-    // default view showing normal month grid; handled by 'getComponents' function
-    return <></>;
-  };
-
-  const getComponents = () => {
     if (actionState === 'default') {
       return { Chevron, MonthCaption };
     }
 
-    return {
-      Chevron,
-      MonthCaption,
-      MonthGrid,
-    };
-  };
+    const MonthGrid = createCalendarMonthGrid({
+      actionState,
+      setActionState,
+      activeMonth,
+      setActiveMonth,
+      monthButtonRef,
+      yearButtonRef,
+      startMonth: props.startMonth,
+      endMonth: props.endMonth,
+    });
+
+    return { Chevron, MonthCaption, MonthGrid };
+  }, [actionState, activeMonth, props.endMonth, props.startMonth]);
 
   const defaultMonth =
     props.defaultMonth ??
@@ -174,23 +86,17 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
           focus-within:relative focus-within:z-20 focus:opacity-100 focus:ring-2
           focus:ring-offset-0`,
         ),
-        range_start:
-          'rounded-l-full aria-selected:bg-accent [&>button]:bg-primary [&>button]:text-primary-foreground',
-        range_end:
-          'rounded-r-full aria-selected:bg-accent [&>button]:bg-primary [&>button]:text-primary-foreground',
-        /* This is needed to ensure that the selected day's cell has rounded corners */
-        selected:
-          props?.mode !== 'range' ? '[&>button]:bg-primary [&>button]:text-primary-foreground' : '',
-        today:
-          '[&>button]:rounded-l-full [&>button]:rounded-r-full [&>button]:bg-accent [&>button]:text-accent-foreground',
+        range_start: `rounded-l-full aria-selected:bg-accent [&>button]:bg-primary [&>button]:text-primary-foreground`,
+        range_end: `rounded-r-full aria-selected:bg-accent [&>button]:bg-primary [&>button]:text-primary-foreground`,
+        selected: selectedDay,
+        today: `[&>button]:rounded-l-full [&>button]:rounded-r-full [&>button]:bg-accent [&>button]:text-accent-foreground`,
         outside: cn('day-outside', outsideDayText),
         disabled: 'text-muted-foreground opacity-50',
-        range_middle:
-          'first:rounded-l-md last:rounded-r-md aria-selected:bg-accent aria-selected:text-accent-foreground',
+        range_middle: `first:rounded-l-md last:rounded-r-md aria-selected:bg-accent aria-selected:text-accent-foreground`,
         hidden: 'invisible',
         ...classNames,
       }}
-      components={getComponents()}
+      components={components}
       defaultMonth={defaultMonth}
       month={activeMonth}
       showOutsideDays={showOutsideDays}

--- a/src/components/Calendar/src/CalendarChevron.tsx
+++ b/src/components/Calendar/src/CalendarChevron.tsx
@@ -1,0 +1,19 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronProps } from 'react-day-picker';
+import { CalendarActionState } from '../types';
+
+function createCalendarChevron(actionState: CalendarActionState) {
+  function CalendarChevron(props: ChevronProps) {
+    if (actionState === 'month' || actionState === 'year') return <></>;
+
+    const { orientation } = props;
+    if (orientation === 'left') return <ChevronLeft {...props} />;
+    return <ChevronRight {...props} />;
+  }
+
+  CalendarChevron.displayName = 'CalendarChevron';
+
+  return CalendarChevron;
+}
+
+export { createCalendarChevron };

--- a/src/components/Calendar/src/CalendarMonthCaption.tsx
+++ b/src/components/Calendar/src/CalendarMonthCaption.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@/components/Button';
+import { cn } from '@/lib/utils';
+import { MonthCaptionProps } from 'react-day-picker';
+import { CalendarMonthCaptionDeps } from '../types';
+import { focusButton } from './calendar-utils';
+
+function createCalendarMonthCaption(deps: CalendarMonthCaptionDeps) {
+  const { actionState, setActionState, monthButtonRef, yearButtonRef, navHeight } = deps;
+
+  function CalendarMonthCaption(props: MonthCaptionProps) {
+    const { calendarMonth } = props;
+
+    return (
+      <div
+        className={cn(
+          navHeight,
+          'relative mx-12 flex items-center justify-center text-sm font-medium',
+        )}
+      >
+        <Button
+          ref={monthButtonRef}
+          aria-label="Select calendar month"
+          className="px-1.5 focus:ring-2 focus:ring-offset-0"
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            if (actionState === 'month') {
+              setActionState('default');
+              focusButton(monthButtonRef);
+              return;
+            }
+
+            setActionState('month');
+          }}
+        >
+          {calendarMonth.date.toLocaleString('default', { month: 'long' })}
+        </Button>
+        <Button
+          ref={yearButtonRef}
+          aria-label="Select calendar year"
+          className="px-1.5 focus:ring-2 focus:ring-offset-0"
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            if (actionState === 'year') {
+              setActionState('default');
+              focusButton(yearButtonRef);
+              return;
+            }
+
+            setActionState('year');
+          }}
+        >
+          {calendarMonth.date.getFullYear()}
+        </Button>
+      </div>
+    );
+  }
+
+  CalendarMonthCaption.displayName = 'CalendarMonthCaption';
+
+  return CalendarMonthCaption;
+}
+
+export { createCalendarMonthCaption };

--- a/src/components/Calendar/src/CalendarMonthGrid.tsx
+++ b/src/components/Calendar/src/CalendarMonthGrid.tsx
@@ -1,0 +1,57 @@
+import { CalendarMonthGridDeps } from '../types';
+import { CalendarMonthPicker } from './CalendarMonthPicker';
+import { CalendarYearPicker } from './CalendarYearPicker';
+import { focusButton } from './calendar-utils';
+
+function createCalendarMonthGrid(deps: CalendarMonthGridDeps) {
+  const {
+    actionState,
+    setActionState,
+    activeMonth,
+    setActiveMonth,
+    monthButtonRef,
+    yearButtonRef,
+    startMonth,
+    endMonth,
+  } = deps;
+
+  function CalendarMonthGrid() {
+    if (actionState === 'month') {
+      return (
+        <CalendarMonthPicker
+          onSelect={month => {
+            const newMonth = activeMonth ? new Date(activeMonth) : new Date();
+            newMonth.setMonth(month);
+            setActiveMonth(newMonth);
+            setActionState('default');
+            focusButton(monthButtonRef);
+          }}
+        />
+      );
+    }
+
+    if (actionState === 'year') {
+      return (
+        <CalendarYearPicker
+          endMonth={endMonth}
+          startMonth={startMonth}
+          onSelect={year => {
+            const newYear = activeMonth ? new Date(activeMonth) : new Date();
+            newYear.setFullYear(year);
+            setActiveMonth(newYear);
+            setActionState('default');
+            focusButton(yearButtonRef);
+          }}
+        />
+      );
+    }
+
+    return <></>;
+  }
+
+  CalendarMonthGrid.displayName = 'CalendarMonthGrid';
+
+  return CalendarMonthGrid;
+}
+
+export { createCalendarMonthGrid };

--- a/src/components/Calendar/src/calendar-utils.ts
+++ b/src/components/Calendar/src/calendar-utils.ts
@@ -1,0 +1,9 @@
+import { MutableRefObject } from 'react';
+
+function focusButton(ref: MutableRefObject<HTMLButtonElement | null>) {
+  setTimeout(() => {
+    ref.current?.focus();
+  }, 0);
+}
+
+export { focusButton };

--- a/src/components/Calendar/types.ts
+++ b/src/components/Calendar/types.ts
@@ -1,5 +1,26 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, MutableRefObject } from 'react';
 import { DayPicker } from 'react-day-picker';
+
+export type CalendarActionState = 'month' | 'year' | 'default';
+
+export type CalendarMonthCaptionDeps = {
+  actionState: CalendarActionState;
+  setActionState: (state: CalendarActionState) => void;
+  monthButtonRef: MutableRefObject<HTMLButtonElement | null>;
+  yearButtonRef: MutableRefObject<HTMLButtonElement | null>;
+  navHeight: string;
+};
+
+export type CalendarMonthGridDeps = {
+  actionState: CalendarActionState;
+  setActionState: (state: CalendarActionState) => void;
+  activeMonth: Date | undefined;
+  setActiveMonth: (date: Date | undefined) => void;
+  monthButtonRef: MutableRefObject<HTMLButtonElement | null>;
+  yearButtonRef: MutableRefObject<HTMLButtonElement | null>;
+  startMonth?: Date;
+  endMonth?: Date;
+};
 
 export type CalendarMonthPickerProps = {
   onSelect?: (month: number) => void;

--- a/src/components/Command/src/Command.test.tsx
+++ b/src/components/Command/src/Command.test.tsx
@@ -403,8 +403,7 @@ describe('Command', () => {
       const item = screen.getByRole('option', { name: 'Item 1' });
       expect(item.className).toContain('text-foreground');
       expect(item.className).toContain('aria-selected:bg-accent');
-      expect(item.className).toContain('aria-selected:text-foreground');
-      expect(item.className).not.toContain('aria-selected:text-accent-foreground');
+      expect(item.className).toContain('aria-selected:text-accent-foreground');
     });
 
     it('is keyboard navigable', async () => {

--- a/src/components/Command/src/CommandItem.tsx
+++ b/src/components/Command/src/CommandItem.tsx
@@ -12,7 +12,7 @@ const CommandItem = React.forwardRef<
     className={cn(
       `relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm
       text-foreground outline-none aria-disabled:pointer-events-none aria-disabled:opacity-50
-      aria-selected:bg-accent aria-selected:text-foreground`,
+      aria-selected:bg-accent aria-selected:text-accent-foreground`,
       className,
     )}
     {...props}

--- a/src/components/MultiSelect/src/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/src/MultiSelect.test.tsx
@@ -371,7 +371,7 @@ describe('MultiSelect', () => {
 
       const option = screen.getByRole('option', { name: /React/ });
       expect(option.className).toContain('aria-selected:bg-accent');
-      expect(option.className).toContain('aria-selected:text-foreground');
+      expect(option.className).toContain('aria-selected:text-accent-foreground');
     });
 
     it('trigger has aria-expanded=false when closed', () => {


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Darker/bolder weekday labels
- Outside day WCAG AA color contrast gray updates
- Added a bit of white inset to selected day between ring and background to help it stand out

### Screenshots

<img width="433" height="608" alt="image" src="https://github.com/user-attachments/assets/4aa7ea05-9988-4838-9e3c-b153db9ed2c1" />

<img width="742" height="608" alt="image" src="https://github.com/user-attachments/assets/9e99fedd-6648-4e7d-9f0d-3c60c71b9854" />