### PR TITLE
Feature: Simplified & Standardized Autocomplete

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -293,12 +293,12 @@ export const App: React.FC = () => {
           >
             <Autocomplete
               debounceMs={500}
-              labelKey="label"
+              getOptionLabel={o => o.label}
+              getOptionValue={o => o.value}
               loadOptions={mockSearchLibraries}
               minSearch={1}
               placeholder="Search libraries..."
               value={searchQuery}
-              valueKey="value"
               onChange={newValue => setSearchQuery(newValue)}
             />
           </FormItem>

--- a/src/components/Autocomplete/demos/AutocompleteDefault.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteDefault.tsx
@@ -11,11 +11,11 @@ interface AutocompleteOption {
 export const AutocompleteDefault = ({
   value: initialValue = '',
   ...args
-}: AutocompleteProps<AutocompleteOption, 'value', 'label'>) => {
+}: AutocompleteProps<AutocompleteOption>) => {
   const [value, setValue] = useState<string>(initialValue);
   return (
     <div className="space-y-4">
-      <Autocomplete<AutocompleteOption, 'value', 'label'>
+      <Autocomplete<AutocompleteOption>
         {...args}
         labelKey="label"
         loadOptions={mockSearchLibraries}

--- a/src/components/Autocomplete/demos/AutocompleteDefault.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteDefault.tsx
@@ -17,11 +17,11 @@ export const AutocompleteDefault = ({
     <div className="space-y-4">
       <Autocomplete<AutocompleteOption>
         {...args}
-        labelKey="label"
+        getOptionLabel={o => o.label}
+        getOptionValue={o => o.value}
         loadOptions={mockSearchLibraries}
         placeholder="Search..."
         value={value}
-        valueKey="value"
         onChange={newValue => setValue(newValue)}
       />
       <p className="text-sm text-muted-foreground">Selected value: {value || 'none'}</p>

--- a/src/components/Autocomplete/demos/AutocompleteMinWidthPopover.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteMinWidthPopover.tsx
@@ -23,12 +23,12 @@ export const AutocompleteMinWidthPopover = (
       <Autocomplete<AutocompleteOption>
         {...args}
         className="w-72"
-        labelKey="label"
+        getOptionLabel={o => o.label}
+        getOptionValue={o => o.value}
         options={options}
         placeholder="Select..."
         popoverClassName="min-w-[50rem]"
         value={value}
-        valueKey="value"
         onChange={newValue => setValue(newValue)}
       />
       <p className="text-sm text-muted-foreground">Selected value: {value || 'none'}</p>

--- a/src/components/Autocomplete/demos/AutocompleteMinWidthPopover.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteMinWidthPopover.tsx
@@ -15,12 +15,12 @@ const options: AutocompleteOption[] = [
 ];
 
 export const AutocompleteMinWidthPopover = (
-  args: Partial<AutocompleteProps<AutocompleteOption, 'value', 'label'>>,
+  args: Partial<AutocompleteProps<AutocompleteOption>>,
 ) => {
   const [value, setValue] = useState<string>('');
   return (
     <div className="space-y-4">
-      <Autocomplete<AutocompleteOption, 'value', 'label'>
+      <Autocomplete<AutocompleteOption>
         {...args}
         className="w-72"
         labelKey="label"

--- a/src/components/Autocomplete/demos/AutocompleteWithCustomRender.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithCustomRender.tsx
@@ -20,7 +20,8 @@ export const AutocompleteWithCustomRender = ({
     <div className="space-y-4">
       <Autocomplete<AutocompleteOption>
         {...args}
-        labelKey="label"
+        getOptionLabel={o => o.label}
+        getOptionValue={o => o.value}
         options={[
           {
             value: 'react',
@@ -74,7 +75,6 @@ export const AutocompleteWithCustomRender = ({
           );
         }}
         value={value}
-        valueKey="value"
         onChange={newValue => setValue(newValue)}
       />
       <p className="text-sm text-muted-foreground">Selected value: {value || 'none'}</p>

--- a/src/components/Autocomplete/demos/AutocompleteWithCustomRender.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithCustomRender.tsx
@@ -14,11 +14,11 @@ interface AutocompleteOption {
 export const AutocompleteWithCustomRender = ({
   value: initialValue = '',
   ...args
-}: AutocompleteProps<AutocompleteOption, 'value', 'label'>) => {
+}: AutocompleteProps<AutocompleteOption>) => {
   const [value, setValue] = useState<string>(initialValue);
   return (
     <div className="space-y-4">
-      <Autocomplete<AutocompleteOption, 'value', 'label'>
+      <Autocomplete<AutocompleteOption>
         {...args}
         labelKey="label"
         options={[

--- a/src/components/Autocomplete/demos/AutocompleteWithItemCallback.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithItemCallback.tsx
@@ -28,8 +28,8 @@ export const AutocompleteWithItemCallback = ({
     <div className="space-y-4">
       <Autocomplete<User>
         {...args}
+        getOptionLabel={u => u.name}
         getOptionValue={u => String(u.id)}
-        labelKey="name"
         options={users}
         placeholder="Select a user..."
         value={value}

--- a/src/components/Autocomplete/demos/AutocompleteWithItemCallback.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithItemCallback.tsx
@@ -12,8 +12,8 @@ interface User {
 export const AutocompleteWithItemCallback = ({
   value: initialValue = '',
   ...args
-}: AutocompleteProps<User, 'id', 'name'>) => {
-  const [value, setValue] = useState<number | ''>(initialValue);
+}: AutocompleteProps<User>) => {
+  const [value, setValue] = useState<string>(initialValue);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
 
   const users: User[] = [
@@ -26,13 +26,13 @@ export const AutocompleteWithItemCallback = ({
 
   return (
     <div className="space-y-4">
-      <Autocomplete<User, 'id', 'name'>
+      <Autocomplete<User>
         {...args}
+        getOptionValue={u => String(u.id)}
         labelKey="name"
         options={users}
         placeholder="Select a user..."
         value={value}
-        valueKey="id"
         onChange={(newValue, item) => {
           setValue(newValue);
           setSelectedUser(item || null);

--- a/src/components/Autocomplete/demos/AutocompleteWithRenderValue.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithRenderValue.tsx
@@ -69,6 +69,7 @@ export const AutocompleteWithRenderValue = () => {
   return (
     <div className="space-y-4">
       <Autocomplete<TeamMember>
+        getOptionLabel={m => `${m.firstName} ${m.lastName}`}
         getOptionValue={m => m.id}
         options={members}
         placeholder="Select a team member..."

--- a/src/components/Autocomplete/demos/AutocompleteWithRenderValue.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithRenderValue.tsx
@@ -1,0 +1,101 @@
+import { cn } from '@/lib/utils';
+import { Check } from 'lucide-react';
+import { useState } from 'react';
+import { Autocomplete } from '../src/Autocomplete';
+
+interface TeamMember {
+  id: string;
+  firstName: string;
+  lastName: string;
+  department: string;
+  avatarColor: string;
+}
+
+const members: TeamMember[] = [
+  {
+    id: 'am',
+    firstName: 'Alice',
+    lastName: 'Martin',
+    department: 'Engineering',
+    avatarColor: 'bg-blue-500',
+  },
+  {
+    id: 'bk',
+    firstName: 'Bob',
+    lastName: 'Kim',
+    department: 'Design',
+    avatarColor: 'bg-purple-500',
+  },
+  {
+    id: 'cp',
+    firstName: 'Clara',
+    lastName: 'Patel',
+    department: 'Product',
+    avatarColor: 'bg-green-500',
+  },
+  {
+    id: 'dw',
+    firstName: 'David',
+    lastName: 'Wu',
+    department: 'Engineering',
+    avatarColor: 'bg-orange-500',
+  },
+  {
+    id: 'en',
+    firstName: 'Eva',
+    lastName: 'Novak',
+    department: 'Design',
+    avatarColor: 'bg-pink-500',
+  },
+];
+
+function Avatar({ member, size = 'md' }: { member: TeamMember; size?: 'sm' | 'md' }) {
+  const initials = `${member.firstName[0]}${member.lastName[0]}`;
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center rounded-full font-medium text-white',
+        member.avatarColor,
+        size === 'sm' ? 'h-5 w-5 text-[0.625rem]' : 'h-7 w-7 text-xs',
+      )}
+    >
+      {initials}
+    </span>
+  );
+}
+
+export const AutocompleteWithRenderValue = () => {
+  const [value, setValue] = useState('');
+  return (
+    <div className="space-y-4">
+      <Autocomplete<TeamMember>
+        getOptionValue={m => m.id}
+        options={members}
+        placeholder="Select a team member..."
+        renderOption={(member, isSelected) => (
+          <div className="flex w-full items-center gap-3">
+            <Check className={cn('h-4 w-4 shrink-0', isSelected ? 'opacity-100' : 'opacity-0')} />
+            <Avatar member={member} />
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">
+                {member.firstName} {member.lastName}
+              </span>
+              <span className="text-xs text-muted-foreground">{member.department}</span>
+            </div>
+          </div>
+        )}
+        renderValue={member => (
+          <div className="flex items-center gap-2">
+            <Avatar member={member} size="sm" />
+            <span>
+              {member.firstName} {member.lastName}
+            </span>
+          </div>
+        )}
+        value={value}
+        onChange={setValue}
+      />
+      <p className="text-sm text-muted-foreground">Selected ID: {value || 'none'}</p>
+    </div>
+  );
+};

--- a/src/components/Autocomplete/demos/AutocompleteWithStaticOptions.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithStaticOptions.tsx
@@ -10,11 +10,11 @@ interface AutocompleteOption {
 export const AutocompleteWithStaticOptions = ({
   value: initialValue = '',
   ...args
-}: AutocompleteProps<AutocompleteOption, 'value', 'label'>) => {
+}: AutocompleteProps<AutocompleteOption>) => {
   const [value, setValue] = useState<string>(initialValue);
   return (
     <div className="space-y-4">
-      <Autocomplete<AutocompleteOption, 'value', 'label'>
+      <Autocomplete<AutocompleteOption>
         {...args}
         labelKey="label"
         options={[

--- a/src/components/Autocomplete/demos/AutocompleteWithStaticOptions.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteWithStaticOptions.tsx
@@ -16,7 +16,8 @@ export const AutocompleteWithStaticOptions = ({
     <div className="space-y-4">
       <Autocomplete<AutocompleteOption>
         {...args}
-        labelKey="label"
+        getOptionLabel={o => o.label}
+        getOptionValue={o => o.value}
         options={[
           { value: '1', label: 'Option 1' },
           { value: '2', label: 'Option 2' },
@@ -24,7 +25,6 @@ export const AutocompleteWithStaticOptions = ({
         ]}
         placeholder="Select an option..."
         value={value}
-        valueKey="value"
         onChange={newValue => setValue(newValue)}
       />
       <p className="text-sm text-muted-foreground">Selected value: {value || 'none'}</p>

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -38,9 +38,8 @@ function AutocompleteInner<T>(
     autoFocus,
     renderOption,
     renderValue,
-    valueKey,
-    labelKey,
     getOptionValue,
+    getOptionLabel,
     ...props
   }: AutocompleteProps<T>,
   ref: React.ForwardedRef<HTMLButtonElement>,
@@ -60,9 +59,7 @@ function AutocompleteInner<T>(
   // Cleanup timer on unmount
   useEffect(() => {
     return () => {
-      if (debounceTimer.current) {
-        clearTimeout(debounceTimer.current);
-      }
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
     };
   }, []);
 
@@ -72,18 +69,13 @@ function AutocompleteInner<T>(
   }, [value]);
 
   const getOptionValueFn = useCallback(
-    (option: T): string => {
-      if (getOptionValue) return getOptionValue(option);
-      if (valueKey) return String((option as Record<string, unknown>)[String(valueKey)] ?? '');
-      return '';
-    },
-    [getOptionValue, valueKey],
+    (option: T): string => (getOptionValue ? getOptionValue(option) : ''),
+    [getOptionValue],
   );
 
   const fetchOptions = useCallback(
     async (search: string) => {
       if (!loadOptions) return;
-
       try {
         setLoading(true);
         setError(false);
@@ -104,20 +96,17 @@ function AutocompleteInner<T>(
   // Filter static options
   const filteredStaticOptions = useMemo(() => {
     if (loadOptions) return []; // Don't show static options in async mode
-
     const normalizedInput = inputValue.toLowerCase().trim();
     return options
       .filter(option => {
         if (normalizedInput.length === 0) return true;
-        if (labelKey) {
-          const label = (option as Record<string, unknown>)[String(labelKey)];
-          if (typeof label === 'string' && label.toLowerCase().includes(normalizedInput))
-            return true;
-        }
-        return getOptionValueFn(option).toLowerCase().includes(normalizedInput);
+        const searchTarget = getOptionLabel
+          ? getOptionLabel(option).toLowerCase()
+          : getOptionValueFn(option).toLowerCase();
+        return searchTarget.includes(normalizedInput);
       })
       .slice(0, maxSuggestions);
-  }, [loadOptions, options, inputValue, maxSuggestions, labelKey, getOptionValueFn]);
+  }, [loadOptions, options, inputValue, maxSuggestions, getOptionLabel, getOptionValueFn]);
 
   // Combined options for rendering
   const displayOptions = loadOptions ? asyncOptions : filteredStaticOptions;
@@ -155,15 +144,11 @@ function AutocompleteInner<T>(
       }
 
       // Clear existing timer
-      if (debounceTimer.current) {
-        clearTimeout(debounceTimer.current);
-      }
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
 
       // Handle async search
       if (loadOptions && input.length >= minSearch) {
-        debounceTimer.current = setTimeout(() => {
-          fetchOptions(input);
-        }, debounceMs);
+        debounceTimer.current = setTimeout(() => fetchOptions(input), debounceMs);
       } else if (loadOptions && input.length === 0) {
         setAsyncOptions([]);
       }
@@ -204,9 +189,7 @@ function AutocompleteInner<T>(
               {displayItem
                 ? renderValue
                   ? renderValue(displayItem)
-                  : labelKey
-                    ? String((displayItem as Record<string, unknown>)[String(labelKey)] ?? value)
-                    : value
+                  : (getOptionLabel?.(displayItem) ?? value)
                 : value || placeholder}
             </span>
             <div className="flex items-center gap-1">
@@ -263,11 +246,7 @@ function AutocompleteInner<T>(
                                 isSelected ? 'opacity-100' : 'opacity-0',
                               )}
                             />
-                            {labelKey
-                              ? String(
-                                  (option as Record<string, unknown>)[String(labelKey)] ?? optValue,
-                                )
-                              : optValue}
+                            {getOptionLabel?.(option) ?? optValue}
                           </>
                         )}
                       </CommandItem>

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -14,9 +14,8 @@ import { getZIndex } from '@/lib/z-index';
 import { Check, ChevronsUpDown, X } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AutocompleteProps } from '../types';
-import { extractOptionFields } from './utils';
 
-function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
+function AutocompleteInner<T>(
   {
     loadOptions,
     options = [],
@@ -38,10 +37,12 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
     required,
     autoFocus,
     renderOption,
+    renderValue,
     valueKey,
     labelKey,
+    getOptionValue,
     ...props
-  }: AutocompleteProps<T, K, L>,
+  }: AutocompleteProps<T>,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
   const [open, setOpen] = useState(false);
@@ -51,6 +52,7 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
   const [error, setError] = useState(false);
   const [asyncOptions, setAsyncOptions] = useState<T[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<T | undefined>(undefined);
 
   // Debounce timer reference
   const debounceTimer = useRef<NodeJS.Timeout>();
@@ -63,6 +65,20 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
       }
     };
   }, []);
+
+  // Clear selectedItem when value is externally cleared
+  useEffect(() => {
+    if (!value) setSelectedItem(undefined);
+  }, [value]);
+
+  const getOptionValueFn = useCallback(
+    (option: T): string => {
+      if (getOptionValue) return getOptionValue(option);
+      if (valueKey) return String((option as Record<string, unknown>)[String(valueKey)] ?? '');
+      return '';
+    },
+    [getOptionValue, valueKey],
+  );
 
   const fetchOptions = useCallback(
     async (search: string) => {
@@ -90,58 +106,42 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
     if (loadOptions) return []; // Don't show static options in async mode
 
     const normalizedInput = inputValue.toLowerCase().trim();
-    if (normalizedInput.length > 0) {
-      setHasSearched(true);
-    }
     return options
       .filter(option => {
-        const opt = option as Record<string, unknown>;
-        const valueKeyStr = String(valueKey);
-        const labelKeyStr = String(labelKey);
-        return (
-          (typeof opt[labelKeyStr] === 'string' &&
-            String(opt[labelKeyStr]).toLowerCase().includes(normalizedInput)) ||
-          (typeof opt[valueKeyStr] === 'string' &&
-            String(opt[valueKeyStr]).toLowerCase().includes(normalizedInput))
-        );
+        if (normalizedInput.length === 0) return true;
+        if (labelKey) {
+          const label = (option as Record<string, unknown>)[String(labelKey)];
+          if (typeof label === 'string' && label.toLowerCase().includes(normalizedInput))
+            return true;
+        }
+        return getOptionValueFn(option).toLowerCase().includes(normalizedInput);
       })
       .slice(0, maxSuggestions);
-  }, [loadOptions, options, inputValue, maxSuggestions, valueKey, labelKey]);
+  }, [loadOptions, options, inputValue, maxSuggestions, labelKey, getOptionValueFn]);
 
   // Combined options for rendering
   const displayOptions = loadOptions ? asyncOptions : filteredStaticOptions;
 
-  // Convert value to string for comparison
-  const valueAsString = useMemo(() => {
-    if (value === '') return '';
-    return String(value);
-  }, [value]);
-
-  const valueKeyStr = String(valueKey);
-
-  const selectedOption = useMemo(
-    () =>
-      displayOptions.find(
-        option => String((option as Record<string, unknown>)[valueKeyStr]) === valueAsString,
-      ),
-    [displayOptions, valueAsString, valueKeyStr],
-  );
+  // For externally-controlled values, look up the item from static options
+  const displayItem = useMemo(() => {
+    if (selectedItem) return selectedItem;
+    if (!value) return undefined;
+    if (!loadOptions) return options.find(o => getOptionValueFn(o) === value);
+    return undefined;
+  }, [selectedItem, value, loadOptions, options, getOptionValueFn]);
 
   const handleSelect = useCallback(
     (selectedValue: string) => {
-      // Find the option and extract the typed value
-      const option = displayOptions.find(
-        opt => String((opt as Record<string, unknown>)[valueKeyStr]) === selectedValue,
-      );
+      const option = displayOptions.find(opt => getOptionValueFn(opt) === selectedValue);
       if (option) {
-        const typedValue = (option as Record<string, unknown>)[valueKeyStr] as T[K];
-        onChange(typedValue, option);
+        setSelectedItem(option);
+        onChange(selectedValue, option);
       }
       setOpen(false);
       setInputValue('');
       setHasSearched(false);
     },
-    [onChange, displayOptions, valueKeyStr],
+    [onChange, displayOptions, getOptionValueFn],
   );
 
   const handleInputChange = useCallback(
@@ -150,6 +150,8 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
 
       if (input.length === 0) {
         setHasSearched(false);
+      } else if (!loadOptions) {
+        setHasSearched(true);
       }
 
       // Clear existing timer
@@ -170,7 +172,8 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
   );
 
   const handleClear = useCallback(() => {
-    onChange('' as T[K], undefined);
+    onChange('', undefined);
+    setSelectedItem(undefined);
     setInputValue('');
     setAsyncOptions([]);
     setHasSearched(false);
@@ -179,12 +182,7 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
   return (
     <>
       {name || required ? (
-        <input
-          name={name}
-          required={required}
-          type="hidden"
-          value={value === '' ? '' : String(value)}
-        />
+        <input name={name} required={required} type="hidden" value={value} />
       ) : null}
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
@@ -194,7 +192,7 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
             autoFocus={autoFocus}
             className={cn(
               'w-full justify-between px-3',
-              !selectedOption && !value && 'text-muted-foreground',
+              !value && 'text-muted-foreground',
               className,
             )}
             isDisabled={isDisabled}
@@ -203,19 +201,16 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
             {...props}
           >
             <span className="truncate">
-              {(() => {
-                if (selectedOption) {
-                  const label = (selectedOption as Record<string, unknown>)[String(labelKey)];
-                  if (typeof label === 'string') {
-                    return label;
-                  }
-                  return value ? String(value) : placeholder;
-                }
-                return value ? String(value) : placeholder;
-              })()}
+              {displayItem
+                ? renderValue
+                  ? renderValue(displayItem)
+                  : labelKey
+                    ? String((displayItem as Record<string, unknown>)[String(labelKey)] ?? value)
+                    : value
+                : value || placeholder}
             </span>
             <div className="flex items-center gap-1">
-              {(value !== '' && value) || inputValue ? (
+              {value || inputValue ? (
                 <X
                   className="h-4 w-4 opacity-50 hover:opacity-100"
                   onClick={e => {
@@ -247,19 +242,13 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
             {!loading && !error && displayOptions.length > 0 ? (
               <CommandList className={cn('max-h-[16.5rem] overflow-y-auto', listClassName)}>
                 <CommandGroup>
-                  {displayOptions.map(option => {
-                    const { value: optValue, label: optLabel } = extractOptionFields(
-                      option,
-                      valueKey,
-                      labelKey,
-                    );
-                    const isSelected = Boolean(
-                      optValue && value !== '' && optValue === valueAsString,
-                    );
+                  {displayOptions.map((option, index) => {
+                    const optValue = getOptionValueFn(option);
+                    const isSelected = Boolean(optValue && value && optValue === value);
 
                     return (
                       <CommandItem
-                        key={optValue}
+                        key={optValue || index}
                         className="cursor-pointer"
                         value={optValue}
                         onSelect={handleSelect}
@@ -274,7 +263,11 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
                                 isSelected ? 'opacity-100' : 'opacity-0',
                               )}
                             />
-                            {optLabel}
+                            {labelKey
+                              ? String(
+                                  (option as Record<string, unknown>)[String(labelKey)] ?? optValue,
+                                )
+                              : optValue}
                           </>
                         )}
                       </CommandItem>
@@ -293,8 +286,8 @@ function AutocompleteInner<T, K extends keyof T, L extends keyof T>(
 const AutocompleteBase = React.forwardRef(AutocompleteInner);
 AutocompleteBase.displayName = 'Autocomplete';
 
-const Autocomplete = AutocompleteBase as unknown as <T, K extends keyof T, L extends keyof T>(
-  props: AutocompleteProps<T, K, L> & { ref?: React.ForwardedRef<HTMLButtonElement> },
+const Autocomplete = AutocompleteBase as unknown as <T>(
+  props: AutocompleteProps<T> & { ref?: React.ForwardedRef<HTMLButtonElement> },
 ) => React.ReactElement;
 
 export { Autocomplete };

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -4,6 +4,8 @@ import { AutocompleteDefault } from '../demos/AutocompleteDefault';
 import sourceCodeDefault from '../demos/AutocompleteDefault.tsx?raw';
 import { AutocompleteWithCustomRender } from '../demos/AutocompleteWithCustomRender';
 import sourceCodeWithCustomRender from '../demos/AutocompleteWithCustomRender.tsx?raw';
+import { AutocompleteWithRenderValue } from '../demos/AutocompleteWithRenderValue';
+import sourceCodeWithRenderValue from '../demos/AutocompleteWithRenderValue.tsx?raw';
 import { AutocompleteWithItemCallback } from '../demos/AutocompleteWithItemCallback';
 import sourceCodeWithItemCallback from '../demos/AutocompleteWithItemCallback.tsx?raw';
 import { AutocompleteMinWidthPopover } from '../demos/AutocompleteMinWidthPopover';
@@ -176,9 +178,7 @@ export const Playground: Story = {
  * Search for "React" to see results.
  */
 export const Default: Story = {
-  render: () => (
-    <AutocompleteDefault labelKey="label" value="" valueKey="value" onChange={() => {}} />
-  ),
+  render: () => <AutocompleteDefault value="" onChange={() => {}} />,
   // @ts-expect-error - Storybook can't properly infer generic types
   args: {},
   parameters: {
@@ -196,9 +196,7 @@ export const Default: Story = {
  * This shows how the component behaves with a predefined list of options.
  */
 export const WithStaticOptions: Story = {
-  render: () => (
-    <AutocompleteWithStaticOptions labelKey="label" value="" valueKey="value" onChange={() => {}} />
-  ),
+  render: () => <AutocompleteWithStaticOptions value="" onChange={() => {}} />,
   // @ts-expect-error - Storybook can't properly infer generic types
   args: {},
   parameters: {
@@ -212,14 +210,31 @@ export const WithStaticOptions: Story = {
 };
 
 /**
+ * Uses `renderValue` and `renderOption` together with `getOptionValue` — no `labelKey` or
+ * `valueKey` needed. `renderValue` controls what appears in the trigger after a selection;
+ * `renderOption` controls each row in the dropdown.
+ */
+export const WithRenderValue: Story = {
+  render: () => <AutocompleteWithRenderValue />,
+  // @ts-expect-error - Storybook can't properly infer generic types
+  args: {},
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeWithRenderValue,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+/**
  * An example of the Autocomplete component with a custom renderOption function.
  * This demonstrates how to customize the appearance of each option, including showing
  * additional information like descriptions and featured badges.
  */
 export const WithCustomRender: Story = {
-  render: () => (
-    <AutocompleteWithCustomRender labelKey="label" value="" valueKey="value" onChange={() => {}} />
-  ),
+  render: () => <AutocompleteWithCustomRender value="" onChange={() => {}} />,
   // @ts-expect-error - Storybook can't properly infer generic types
   args: {},
   parameters: {
@@ -238,9 +253,7 @@ export const WithCustomRender: Story = {
  * is made, which is useful for displaying additional information or performing actions with the full data.
  */
 export const WithItemCallback: Story = {
-  render: () => (
-    <AutocompleteWithItemCallback labelKey="name" value="" valueKey="id" onChange={() => {}} />
-  ),
+  render: () => <AutocompleteWithItemCallback value="" onChange={() => {}} />,
   // @ts-expect-error - Storybook can't properly infer generic types
   args: {},
   parameters: {
@@ -259,9 +272,7 @@ export const WithItemCallback: Story = {
  * fit long option labels.
  */
 export const MinWidthPopover: Story = {
-  render: () => (
-    <AutocompleteMinWidthPopover labelKey="label" value="" valueKey="value" onChange={() => {}} />
-  ),
+  render: () => <AutocompleteMinWidthPopover value="" onChange={() => {}} />,
   // @ts-expect-error - Storybook can't properly infer generic types
   args: {},
   parameters: {

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -163,7 +163,8 @@ type Story = StoryObj<typeof meta>;
 export const Playground: Story = {
   args: {
     loadOptions: mockSearchLibraries,
-    valueKey: 'value',
+    getOptionValue: (o: { value: string }) => o.value,
+    getOptionLabel: (o: { label: string }) => o.label,
     value: '',
     onChange: () => {},
     placeholder: 'Search...',

--- a/src/components/Autocomplete/types.ts
+++ b/src/components/Autocomplete/types.ts
@@ -1,12 +1,11 @@
 import { ButtonHTMLAttributes } from 'react';
 
-// Pick form-related attributes from SelectHTMLAttributes that we want to support
 type AutocompleteFormAttributes = Pick<
   React.SelectHTMLAttributes<HTMLSelectElement>,
   'name' | 'required' | 'autoFocus'
 >;
 
-export interface AutocompleteProps<T, K extends keyof T, L extends keyof T>
+export interface AutocompleteProps<T>
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange' | 'disabled' | 'value'>,
     AutocompleteFormAttributes {
   /**
@@ -21,26 +20,48 @@ export interface AutocompleteProps<T, K extends keyof T, L extends keyof T>
    */
   options?: T[];
   /**
-   * The currently selected value. Must match the value of one of the options using the valueKey.
+   * The currently selected value as a string.
    * Use an empty string ('') to represent no selection.
    */
-  value: T[K] | '';
+  value: string;
   /**
-   * The key to use for the value property in option objects.
-   * Must be a key of T.
+   * The key on option objects to use as the value for selection and comparison.
+   * The value at this key is stringified for comparison. Provide either this or getOptionValue.
    */
-  valueKey: K;
+  valueKey?: keyof T;
   /**
-   * The key to use for the label property in option objects.
-   * Must be a key of T.
+   * The key on option objects to use as the display label.
+   * Only required when not providing renderOption and renderValue.
    */
-  labelKey: L;
+  labelKey?: keyof T;
+  /**
+   * Function to derive a unique string value from an option object.
+   * Alternative to valueKey — provide one or the other.
+   */
+  getOptionValue?: (option: T) => string;
   /**
    * Callback function invoked when the selected value changes.
-   * @param value - The selected value from the option object.
+   * @param value - The selected option's value as a string, or empty string when clearing.
    * @param item - The full option object, or undefined when clearing the selection.
    */
-  onChange: (value: T[K], item?: T) => void;
+  onChange: (value: string, item?: T) => void;
+  /**
+   * Custom render function for the selected value shown in the trigger button.
+   * Receives the full selected option object.
+   * If not provided, falls back to the labelKey field or the raw value string.
+   * @param option - The currently selected option object.
+   * @returns A React node to render inside the trigger.
+   */
+  renderValue?: (option: T) => React.ReactNode;
+  /**
+   * Custom render function for each option in the dropdown.
+   * Receives the option object and whether it's currently selected.
+   * If not provided, defaults to rendering a Check icon and the labelKey field.
+   * @param option - The option object of type T.
+   * @param isSelected - Whether this option is currently selected.
+   * @returns A React node to render for this option.
+   */
+  renderOption?: (option: T, isSelected: boolean) => React.ReactNode;
   /**
    * Placeholder text displayed when no option is selected.
    * @default 'Select an option...'
@@ -66,7 +87,6 @@ export interface AutocompleteProps<T, K extends keyof T, L extends keyof T>
   maxSuggestions?: number;
   /**
    * Debounce delay for async searches in milliseconds.
-   * Prevents excessive API calls by waiting for the user to stop typing.
    * @default 300
    */
   debounceMs?: number;
@@ -96,27 +116,15 @@ export interface AutocompleteProps<T, K extends keyof T, L extends keyof T>
   zIndex?: number;
   /**
    * Whether the component is disabled.
-   * When true, the autocomplete cannot be interacted with.
    * @default false
    */
   isDisabled?: boolean;
   /**
-   * Custom render function for each option in the dropdown.
-   * Receives the option object and whether it's currently selected.
-   * If not provided, defaults to rendering a Check icon and the option label.
-   * @param option - The option object of type T.
-   * @param isSelected - Whether this option is currently selected.
-   * @returns A React node to render for this option.
-   */
-  renderOption?: (option: T, isSelected: boolean) => React.ReactNode;
-  /**
    * The name attribute for form submission.
-   * This is required for the autocomplete value to be included in form data.
    */
   name?: string;
   /**
    * Whether the autocomplete is required for form validation.
-   * When true, the form cannot be submitted without a selection.
    */
   required?: boolean;
   /**

--- a/src/components/Autocomplete/types.ts
+++ b/src/components/Autocomplete/types.ts
@@ -25,20 +25,16 @@ export interface AutocompleteProps<T>
    */
   value: string;
   /**
-   * The key on option objects to use as the value for selection and comparison.
-   * The value at this key is stringified for comparison. Provide either this or getOptionValue.
-   */
-  valueKey?: keyof T;
-  /**
-   * The key on option objects to use as the display label.
-   * Only required when not providing renderOption and renderValue.
-   */
-  labelKey?: keyof T;
-  /**
-   * Function to derive a unique string value from an option object.
-   * Alternative to valueKey — provide one or the other.
+   * Derives the unique string value for an option, used for selection matching and onChange.
+   * Required unless all options are uniquely identifiable by another means.
    */
   getOptionValue?: (option: T) => string;
+  /**
+   * Derives the display label for an option.
+   * Used as the default label in the dropdown and trigger, and as the field searched when
+   * filtering static options. If not provided, filtering falls back to the option value string.
+   */
+  getOptionLabel?: (option: T) => string;
   /**
    * Callback function invoked when the selected value changes.
    * @param value - The selected option's value as a string, or empty string when clearing.
@@ -47,17 +43,16 @@ export interface AutocompleteProps<T>
   onChange: (value: string, item?: T) => void;
   /**
    * Custom render function for the selected value shown in the trigger button.
-   * Receives the full selected option object.
-   * If not provided, falls back to the labelKey field or the raw value string.
+   * Receives the full selected option object. Falls back to getOptionLabel, then the raw value string.
    * @param option - The currently selected option object.
    * @returns A React node to render inside the trigger.
    */
+
   renderValue?: (option: T) => React.ReactNode;
   /**
    * Custom render function for each option in the dropdown.
    * Receives the option object and whether it's currently selected.
-   * If not provided, defaults to rendering a Check icon and the labelKey field.
-   * @param option - The option object of type T.
+   * If not provided, defaults to rendering a Check icon and the getOptionLabel value.
    * @param isSelected - Whether this option is currently selected.
    * @returns A React node to render for this option.
    */


### PR DESCRIPTION
### Type

- [X] Feature

### Description

- Migrated from `valueKey` and `labelKey` to `getOptionValue` and `getOptionLabel`
- Added ability to custom render the value
- Always use a string for the value
- Removed the need for double TypeScript generics in the definition

### Testing

1. Navigate to http://localhost:3000/testing-route-goes-here
2. Include any setup required (e.g. set a necessary environment variable, etc.)
3. Be specific (include granular steps)
4. Don't make the tester guess what they need to do to test the PR

### Screenshots

<img width="1044" height="645" alt="image" src="https://github.com/user-attachments/assets/71ea2504-c5d9-416c-9417-b52c45d81edd" />

<img width="1056" height="324" alt="image" src="https://github.com/user-attachments/assets/1d127988-084b-49ea-b21a-949e1c121aea" />