### PR TITLE
Fix: Bug fixes to address A11y issues in FormItem and disabled state

### DIFF
--- a/src/components/DateRangePicker/src/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/src/DateRangePicker.tsx
@@ -70,7 +70,6 @@ const DateRangePicker = React.forwardRef<HTMLButtonElement, DateRangePickerProps
                 !value.from && !value.to && 'text-muted-foreground',
               )}
               data-component="date-range-picker"
-              id="date"
               isDisabled={isDisabled}
               variant="input"
               {...props}

--- a/src/components/FormItem/src/FormItem.test.tsx
+++ b/src/components/FormItem/src/FormItem.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FormItem } from './FormItem';
+
+describe('FormItem', () => {
+  it('sets aria-describedby to hintId when hintText is provided', () => {
+    render(
+      <FormItem elementId="test-input" hintText="Hint text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'form-item-test-input-hint');
+  });
+
+  it('sets aria-describedby to errorId when errorText is provided', () => {
+    render(
+      <FormItem elementId="test-input" errorText="Error text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'form-item-test-input-error');
+  });
+
+  it('includes both hint and error IDs when both are provided', () => {
+    render(
+      <FormItem elementId="test-input" errorText="Error text" hintText="Hint text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute(
+      'aria-describedby',
+      'form-item-test-input-hint form-item-test-input-error',
+    );
+  });
+
+  it('does not set aria-describedby when neither hintText nor errorText is provided', () => {
+    render(
+      <FormItem elementId="test-input" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('merges with existing aria-describedby on the child', () => {
+    render(
+      <FormItem elementId="test-input" hintText="Hint text" label="Label">
+        <input aria-describedby="other-description" id="test-input" />
+      </FormItem>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute(
+      'aria-describedby',
+      'form-item-test-input-hint other-description',
+    );
+  });
+
+  it('hint element has the expected id', () => {
+    render(
+      <FormItem elementId="test-input" hintText="Hint text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    expect(document.getElementById('form-item-test-input-hint')).toHaveTextContent('Hint text');
+  });
+
+  it('error element has the expected id', () => {
+    render(
+      <FormItem elementId="test-input" errorText="Error text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    expect(document.getElementById('form-item-test-input-error')).toHaveTextContent('Error text');
+  });
+
+  it('throws when neither elementId nor child id is provided', () => {
+    expect(() =>
+      render(
+        <FormItem label="Label">
+          <input />
+        </FormItem>,
+      ),
+    ).toThrow();
+  });
+});

--- a/src/components/FormItem/src/FormItem.tsx
+++ b/src/components/FormItem/src/FormItem.tsx
@@ -31,6 +31,22 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
     const hintId = `form-item-${childId}-hint`;
     const errorId = `form-item-${childId}-error`;
 
+    // Build aria-describedby from whichever hint/error IDs are active, merging with any
+    // existing aria-describedby on the child so we don't clobber consumer-supplied values.
+    const existingDescribedBy = (children.props as Record<string, unknown>)['aria-describedby'];
+    const describedByIds =
+      [
+        hintText ? hintId : null,
+        errorText ? errorId : null,
+        typeof existingDescribedBy === 'string' ? existingDescribedBy : null,
+      ]
+        .filter(Boolean)
+        .join(' ') || undefined;
+
+    const child = describedByIds
+      ? React.cloneElement(children, { 'aria-describedby': describedByIds })
+      : children;
+
     return (
       <div
         ref={ref}
@@ -58,7 +74,7 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
             ) : null}
           </div>
         ) : null}
-        {children}
+        {child}
         {errorText ? (
           <p className={cn(styles.text.error, 'mb-0 mt-0')} id={errorId}>
             {errorText}

--- a/src/components/Tabs/src/Tabs.tsx
+++ b/src/components/Tabs/src/Tabs.tsx
@@ -50,12 +50,7 @@ const TabsContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content
     ref={ref}
-    className={cn(
-      styles.focusRingVisible,
-      `mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2
-      focus-visible:ring-ring focus-visible:ring-offset-2`,
-      className,
-    )}
+    className={cn(styles.focusRingVisible, 'mt-2', className)}
     {...props}
   />
 ));

--- a/src/components/Tooltip/src/Tooltip.tsx
+++ b/src/components/Tooltip/src/Tooltip.tsx
@@ -13,7 +13,7 @@ function TooltipProvider({
   return <TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />;
 }
 
-const Tooltip = React.forwardRef<React.ElementRef<typeof TooltipPrimitive.Root>, TooltipProps>(
+const Tooltip = React.forwardRef<React.ElementRef<typeof TooltipPrimitive.Content>, TooltipProps>(
   (
     {
       children,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -21,7 +21,6 @@ export type UseAriaDisabledActive = {
   // keyboard events
   onKeyDown: (evt: React.KeyboardEvent) => void;
   onKeyUp: (evt: React.KeyboardEvent) => void;
-  onKeyPress: (evt: React.KeyboardEvent) => void;
 
   // form events
   onInput: (evt: React.FormEvent) => void;

--- a/src/hooks/useAriaDisabled.ts
+++ b/src/hooks/useAriaDisabled.ts
@@ -128,7 +128,6 @@ export function useAriaDisabled({
     // keyboard events
     onKeyDown: handleKeyboardEvent,
     onKeyUp: handleKeyboardEvent,
-    onKeyPress: handleKeyboardEvent,
 
     // form events
     onInput: handleFormEvent,


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Removed ID on DateRangePicker
- Pass through `aria-describedby` to chidlren of FormItem
- Cleaned up duplicative Tab styles
- Fixed Tooltip ref type
- Removed unnecessary `onKeyPress` in `useAriaDisabled` hook
