### PR TITLE
Fix: Alert heading A11y

### DIFF
--- a/src/components/Alert/src/Alert.tsx
+++ b/src/components/Alert/src/Alert.tsx
@@ -2,6 +2,7 @@ import { styles } from '@/lib/styles';
 import { cn } from '@/lib/utils';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from 'lucide-react';
 import * as React from 'react';
+import { useId } from 'react';
 import {
   alertContentVariants,
   alertHeadingVariants,
@@ -27,6 +28,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     ref,
   ) => {
     const HeadingTag = headingLevel;
+    const headingId = useId();
     const icons = {
       success: <CheckCircle2 />,
       warning: <AlertTriangle />,
@@ -35,15 +37,26 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     };
 
     return (
-      <div ref={ref} className={cn(alertVariants({ variant, size }), className)} {...props}>
+      <div
+        ref={ref}
+        aria-labelledby={heading ? headingId : undefined}
+        className={cn(alertVariants({ variant, size }), className)}
+        role="alert"
+        {...props}
+      >
         {hasIcon ? (
-          <span className={cn(alertIconVariants({ variant, size, hasHeading: !!heading }))}>
+          <span
+            aria-hidden="true"
+            className={cn(alertIconVariants({ variant, size, hasHeading: !!heading }))}
+          >
             {icons[variant]}
           </span>
         ) : null}
         <div className={cn(alertContentVariants({ size, hasIcon, hasHeading: !!heading }))}>
           {heading ? (
-            <HeadingTag className={cn(alertHeadingVariants({ size }))}>{heading}</HeadingTag>
+            <HeadingTag className={cn(alertHeadingVariants({ size }))} id={headingId}>
+              {heading}
+            </HeadingTag>
           ) : null}
           {children}
         </div>

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -184,6 +184,13 @@ function AutocompleteInner<T>(
             role="combobox"
             variant="input"
             {...props}
+            onKeyDown={e => {
+              if ((e.key === 'Delete' || e.key === 'Backspace') && value && !open) {
+                e.preventDefault();
+                handleClear();
+              }
+              props.onKeyDown?.(e);
+            }}
           >
             <span className="truncate">
               {displayItem
@@ -192,7 +199,7 @@ function AutocompleteInner<T>(
                   : (getOptionLabel?.(displayItem) ?? value)
                 : value || placeholder}
             </span>
-            <div className="flex items-center gap-1">
+            <div aria-hidden="true" className="flex items-center gap-1">
               {value || inputValue ? (
                 <X
                   className="h-4 w-4 opacity-50 hover:opacity-100"

--- a/src/components/FormItem/src/FormItem.test.tsx
+++ b/src/components/FormItem/src/FormItem.test.tsx
@@ -77,6 +77,26 @@ describe('FormItem', () => {
     expect(document.getElementById('form-item-test-input-error')).toHaveTextContent('Error text');
   });
 
+  it('hint element has a data-testid matching its id', () => {
+    render(
+      <FormItem elementId="test-input" hintText="Hint text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const hint = screen.getByTestId('form-item-test-input-hint');
+    expect(hint).toHaveTextContent('Hint text');
+  });
+
+  it('error element has a data-testid matching its id', () => {
+    render(
+      <FormItem elementId="test-input" errorText="Error text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const error = screen.getByTestId('form-item-test-input-error');
+    expect(error).toHaveTextContent('Error text');
+  });
+
   it('throws when neither elementId nor child id is provided', () => {
     expect(() =>
       render(

--- a/src/components/FormItem/src/FormItem.tsx
+++ b/src/components/FormItem/src/FormItem.tsx
@@ -68,7 +68,7 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
               {labelSlot ? <div className="ml-2 inline-flex">{labelSlot}</div> : null}
             </div>
             {hintText ? (
-              <p className={cn(styles.text.hint, 'mb-0 mt-0')} id={hintId}>
+              <p className={cn(styles.text.hint, 'mb-0 mt-0')} data-testid={hintId} id={hintId}>
                 {hintText}
               </p>
             ) : null}
@@ -76,7 +76,7 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
         ) : null}
         {child}
         {errorText ? (
-          <p className={cn(styles.text.error, 'mb-0 mt-0')} id={errorId}>
+          <p className={cn(styles.text.error, 'mb-0 mt-0')} data-testid={errorId} id={errorId}>
             {errorText}
           </p>
         ) : null}

--- a/src/components/TagInput/src/TagInput.tsx
+++ b/src/components/TagInput/src/TagInput.tsx
@@ -1,5 +1,6 @@
 import { styles } from '@/lib/styles';
 import { cn } from '@/lib/utils';
+import { useAriaDisabled } from '@/hooks/useAriaDisabled';
 import { X } from 'lucide-react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Tag, TagInputProps } from '../types';
@@ -25,6 +26,7 @@ const TagInput = React.forwardRef<HTMLDivElement, TagInputProps>(
     const [focusedTagIndex, setFocusedTagIndex] = useState<number>(-1);
     const inputRef = useRef<HTMLInputElement>(null);
     const tagsRef = useRef<(HTMLButtonElement | null)[]>([]);
+    const tagDisabledProps = useAriaDisabled({ isDisabled });
 
     const delimiters = useMemo(() => {
       if (!delimiterChars) return [];
@@ -123,6 +125,7 @@ const TagInput = React.forwardRef<HTMLDivElement, TagInputProps>(
     };
 
     const handleContainerClick = (evt: React.MouseEvent) => {
+      if (isDisabled) return;
       if (evt.target === evt.currentTarget) {
         inputRef.current?.focus();
         setFocusedTagIndex(-1);
@@ -152,6 +155,7 @@ const TagInput = React.forwardRef<HTMLDivElement, TagInputProps>(
         ) : null}
         <div
           ref={ref}
+          aria-disabled={isDisabled || undefined}
           className={cn(
             styles.input,
             styles.focusRingWithin,
@@ -166,6 +170,7 @@ const TagInput = React.forwardRef<HTMLDivElement, TagInputProps>(
             <button
               key={tag.id}
               ref={el => (tagsRef.current[index] = el)}
+              aria-label={`Remove ${tag.text}`}
               className={cn(
                 `flex items-center gap-1 rounded-sm bg-secondary px-2 py-0.5 text-sm
                 text-secondary-foreground transition-colors`,
@@ -174,33 +179,33 @@ const TagInput = React.forwardRef<HTMLDivElement, TagInputProps>(
                 styles.focusRing,
                 'focus:ring-2 focus:ring-offset-0',
               )}
-              disabled={isDisabled}
               type="button"
-              onClick={evt => evt.stopPropagation()}
+              onClick={evt => {
+                evt.stopPropagation();
+                if (!isDisabled) removeTag(tag.id);
+              }}
               onKeyDown={evt => handleTagKeyDown(evt, index)}
+              {...tagDisabledProps}
             >
               {tag.text}
-              {!isDisabled ? (
-                <X
-                  aria-label={`Remove ${tag.text}`}
-                  className="h-3 w-3 opacity-50 transition-opacity hover:opacity-100"
-                  role="button"
-                  strokeWidth={3}
-                  onClick={evt => {
-                    evt.stopPropagation();
-                    removeTag(tag.id);
-                  }}
-                />
-              ) : null}
+              <X
+                aria-hidden="true"
+                className={cn(
+                  'h-3 w-3 opacity-50 transition-opacity',
+                  !isDisabled && 'hover:opacity-100',
+                )}
+                strokeWidth={3}
+              />
             </button>
           ))}
           <input
             ref={inputRef}
+            aria-disabled={isDisabled || undefined}
             autoFocus={autoFocus}
             className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground
-              disabled:cursor-not-allowed"
-            disabled={isDisabled || (maxTags !== undefined && value.length >= maxTags)}
+              read-only:cursor-not-allowed"
             placeholder={value.length === 0 ? placeholderText : ''}
+            readOnly={isDisabled || (maxTags !== undefined && value.length >= maxTags)}
             type="text"
             value={inputValue}
             onChange={handleInputChange}


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Allow Alert heading to be read back by screen readers
- Address Autocomplete clear button A11y
- Reorg. TagInput disabled state to use `useAriaDisabled`
- Add deterministic `data-testid` to hint and error text in FormItem