### PR TITLE
Chore: Address component inconsistencies

### DIFF
--- a/src/components/Breadcrumbs/src/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/src/Breadcrumbs.tsx
@@ -16,7 +16,9 @@ const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
                   {item.label}
                 </a>
               ) : (
-                <span className="font-medium text-foreground">{item.label}</span>
+                <span aria-current="page" className="font-medium text-foreground">
+                  {item.label}
+                </span>
               )}
               {index < items.length - 1 ? (
                 <span className="text-muted-foreground">{separator}</span>

--- a/src/components/CheckboxGroup/src/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/src/CheckboxGroup.tsx
@@ -14,6 +14,7 @@ const CheckboxGroup = React.forwardRef<HTMLDivElement, CheckboxGroupProps>(
       className,
       columns = 1,
       id: groupId,
+      isDisabled,
       orientation = 'vertical',
       variant = 'default',
       ...props
@@ -34,6 +35,7 @@ const CheckboxGroup = React.forwardRef<HTMLDivElement, CheckboxGroupProps>(
               description={option.description}
               id={inputId}
               isChecked={value.includes(option.id)}
+              isDisabled={isDisabled || option.isDisabled}
               label={option.label}
               variant={variant}
               onCheckedChange={isChecked => {

--- a/src/components/CheckboxGroup/types.ts
+++ b/src/components/CheckboxGroup/types.ts
@@ -5,6 +5,7 @@ export interface CheckboxOption {
   id: string;
   label: string;
   description?: string;
+  isDisabled?: boolean;
   /** Optional explicit id for the checkbox input. Defaults to `${groupId}-${id}` when CheckboxGroup has an id. */
   inputId?: string;
 }
@@ -14,6 +15,7 @@ export interface CheckboxGroupProps extends Omit<HTMLAttributes<HTMLDivElement>,
   value: string[];
   onChange: (value: string[]) => void;
   className?: string;
+  isDisabled?: boolean;
   /** Number of columns for default and tile variants (vertical orientation). Defaults to 1. */
   columns?: 1 | 2 | 3 | 4;
   orientation?: 'horizontal' | 'vertical';

--- a/src/components/DropdownButton/src/DropdownButton.tsx
+++ b/src/components/DropdownButton/src/DropdownButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/Button';
 import { cn } from '@/lib/utils';
+import { getZIndex } from '@/lib/z-index';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { ChevronDown } from 'lucide-react';
 import * as React from 'react';
@@ -18,48 +19,54 @@ const DropdownButton = React.forwardRef<
       align = 'start',
       variant = 'default',
       isDisabled = false,
+      zIndex,
       ...props
     },
     ref,
-  ) => (
-    <DropdownMenuPrimitive.Root>
-      <DropdownMenuPrimitive.Trigger asChild>
-        <Button
-          ref={ref}
-          className={cn('flex items-center gap-1', className)}
-          isDisabled={isDisabled}
-          variant={variant}
-          {...props}
-        >
-          {children}
-          <ChevronDown className="h-4 w-4" />
-        </Button>
-      </DropdownMenuPrimitive.Trigger>
-      <DropdownMenuPrimitive.Portal>
-        <DropdownMenuPrimitive.Content
-          align={align}
-          className="z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover px-1 py-1
-            text-popover-foreground shadow-md data-[state=open]:animate-in
-            data-[state=closed]:animate-out data-[state=closed]:fade-out-0
-            data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95
-            data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2
-            data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
-          sideOffset={4}
-        >
-          {items.map((item, index) =>
-            item === 'separator' ? (
-              <DropdownMenuPrimitive.Separator
-                key={`separator-${index}`}
-                className="my-1 h-px bg-muted"
-              />
-            ) : (
-              <DropdownMenuItem key={item.label} item={item} />
-            ),
-          )}
-        </DropdownMenuPrimitive.Content>
-      </DropdownMenuPrimitive.Portal>
-    </DropdownMenuPrimitive.Root>
-  ),
+  ) => {
+    const resolvedZIndex = getZIndex('dropdown', zIndex);
+    return (
+      <DropdownMenuPrimitive.Root>
+        <DropdownMenuPrimitive.Trigger asChild>
+          <Button
+            ref={ref}
+            className={cn('flex items-center gap-1', className)}
+            isDisabled={isDisabled}
+            variant={variant}
+            {...props}
+          >
+            {children}
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </DropdownMenuPrimitive.Trigger>
+        <DropdownMenuPrimitive.Portal>
+          <DropdownMenuPrimitive.Content
+            align={align}
+            className="min-w-[8rem] overflow-hidden rounded-md border bg-popover px-1 py-1
+              text-popover-foreground shadow-md data-[state=open]:animate-in
+              data-[state=closed]:animate-out data-[state=closed]:fade-out-0
+              data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95
+              data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2
+              data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2
+              data-[side=top]:slide-in-from-bottom-2"
+            sideOffset={4}
+            style={{ zIndex: resolvedZIndex }}
+          >
+            {items.map((item, index) =>
+              item === 'separator' ? (
+                <DropdownMenuPrimitive.Separator
+                  key={`separator-${index}`}
+                  className="my-1 h-px bg-muted"
+                />
+              ) : (
+                <DropdownMenuItem key={item.label} item={item} />
+              ),
+            )}
+          </DropdownMenuPrimitive.Content>
+        </DropdownMenuPrimitive.Portal>
+      </DropdownMenuPrimitive.Root>
+    );
+  },
 );
 DropdownButton.displayName = 'DropdownButton';
 

--- a/src/components/DropdownButton/types.ts
+++ b/src/components/DropdownButton/types.ts
@@ -20,4 +20,5 @@ export interface DropdownButtonProps
   className?: string;
   isDisabled?: boolean;
   align?: 'start' | 'center' | 'end';
+  zIndex?: number;
 }

--- a/src/components/RadioGroup/src/RadioGroup.tsx
+++ b/src/components/RadioGroup/src/RadioGroup.tsx
@@ -19,6 +19,7 @@ const RadioGroup = React.forwardRef<
       className,
       columns = 1,
       id: groupId,
+      isDisabled,
       orientation = 'vertical',
       variant = 'default',
       ...props
@@ -47,6 +48,7 @@ const RadioGroup = React.forwardRef<
                   description={option.description}
                   id={inputId}
                   isChecked={value === option.value}
+                  isDisabled={isDisabled}
                   label={option.label}
                   value={option.value}
                   variant={variant}

--- a/src/components/RadioGroup/src/RadioGroup.tsx
+++ b/src/components/RadioGroup/src/RadioGroup.tsx
@@ -48,7 +48,7 @@ const RadioGroup = React.forwardRef<
                   description={option.description}
                   id={inputId}
                   isChecked={value === option.value}
-                  isDisabled={isDisabled}
+                  isDisabled={isDisabled || option.isDisabled}
                   label={option.label}
                   value={option.value}
                   variant={variant}

--- a/src/components/RadioGroup/types.ts
+++ b/src/components/RadioGroup/types.ts
@@ -5,6 +5,7 @@ export interface RadioOption {
   value: string;
   label: string;
   description?: string;
+  isDisabled?: boolean;
   /** Optional explicit id for the radio input. Defaults to `${groupId}-${value}` when RadioGroup has an id. */
   id?: string;
 }

--- a/src/components/RadioGroup/types.ts
+++ b/src/components/RadioGroup/types.ts
@@ -11,8 +11,9 @@ export interface RadioOption {
 
 type RadioGroupBaseProps = Omit<
   ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>,
-  'onValueChange' | 'onChange'
+  'onValueChange' | 'onChange' | 'disabled'
 > & {
+  isDisabled?: boolean;
   value?: string;
   onChange?: (value: string) => void;
   className?: string;

--- a/src/components/Select/src/Select.tsx
+++ b/src/components/Select/src/Select.tsx
@@ -55,4 +55,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
 );
 Select.displayName = 'Select';
 
-export { Select, SelectGroup, SelectRoot, SelectValue, Select as SingleSelect };
+/** @deprecated Use `Select` instead. */
+const SingleSelect = Select;
+
+export { Select, SelectGroup, SelectRoot, SelectValue, SingleSelect };

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -38,7 +38,7 @@ export interface SelectProps
   autoFocus?: boolean;
 }
 
-// TODO: Remove when removing SingleSelect component
+/** @deprecated Use `SelectProps` instead. */
 export type SingleSelectProps = SelectProps;
 
 export interface SelectTriggerProps

--- a/src/components/Switch/src/Switch.tsx
+++ b/src/components/Switch/src/Switch.tsx
@@ -1,5 +1,6 @@
 import { Label } from '@/components/Label';
 import { useAriaDisabled } from '@/hooks';
+import { validateFormControlProps } from '@/lib/form-controls';
 import { styles } from '@/lib/styles';
 import { cn } from '@/lib/utils';
 import * as SwitchPrimitives from '@radix-ui/react-switch';
@@ -29,14 +30,7 @@ const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, 
     const generatedId = useId();
     const computedId = id ?? generatedId;
 
-    if (!label && !ariaLabel) {
-      throw new Error('Switch must have either a label prop or an aria-label attribute');
-    }
-    if (label && ariaLabel) {
-      throw new Error(
-        'Switch must have either a label prop or an aria-label attribute, but not both',
-      );
-    }
+    validateFormControlProps('Switch', label, ariaLabel);
 
     return (
       <div className="flex items-center space-x-2">

--- a/src/components/SwitchGroup/demos/SwitchGroupHorizontal.tsx
+++ b/src/components/SwitchGroup/demos/SwitchGroupHorizontal.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { SwitchGroup } from '../src/SwitchGroup';
+
+const options = [
+  { id: 'notifications', label: 'Enable notifications' },
+  { id: 'emails', label: 'Receive emails' },
+  { id: 'marketing', label: 'Marketing communications' },
+];
+
+export const SwitchGroupHorizontal = () => {
+  const [value, setValue] = useState<string[]>([]);
+  return (
+    <div className="space-y-4">
+      <SwitchGroup options={options} orientation="horizontal" value={value} onChange={setValue} />
+      <p className="text-sm text-muted-foreground">
+        Selected IDs: {value.length > 0 ? value.join(', ') : 'none'}
+      </p>
+    </div>
+  );
+};

--- a/src/components/SwitchGroup/demos/SwitchGroupVertical.tsx
+++ b/src/components/SwitchGroup/demos/SwitchGroupVertical.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import { SwitchGroup } from '../src/SwitchGroup';
+
+const options = [
+  { id: 'notifications', label: 'Enable notifications' },
+  { id: 'emails', label: 'Receive emails' },
+  { id: 'marketing', label: 'Marketing communications' },
+  { id: 'updates', label: 'Auto-updates' },
+];
+
+export const SwitchGroupVertical = () => {
+  const [value, setValue] = useState<string[]>([]);
+  return (
+    <div className="space-y-4">
+      <SwitchGroup options={options} orientation="vertical" value={value} onChange={setValue} />
+      <p className="text-sm text-muted-foreground">
+        Selected IDs: {value.length > 0 ? value.join(', ') : 'none'}
+      </p>
+    </div>
+  );
+};

--- a/src/components/SwitchGroup/src/SwitchGroup.tsx
+++ b/src/components/SwitchGroup/src/SwitchGroup.tsx
@@ -6,7 +6,16 @@ import { SwitchGroupProps } from '../types';
 
 const SwitchGroup = React.forwardRef<HTMLDivElement, SwitchGroupProps>(
   (
-    { options, value, onChange, className, columns = 1, orientation = 'vertical', ...props },
+    {
+      options,
+      value,
+      onChange,
+      className,
+      columns = 1,
+      isDisabled,
+      orientation = 'vertical',
+      ...props
+    },
     ref,
   ) => {
     const layoutClasses = useFormGroupLayout({ orientation, columns });
@@ -32,7 +41,7 @@ const SwitchGroup = React.forwardRef<HTMLDivElement, SwitchGroupProps>(
             key={option.id}
             id={option.id}
             isChecked={value.includes(option.id)}
-            isDisabled={option.isDisabled}
+            isDisabled={isDisabled || option.isDisabled}
             label={option.label}
             onCheckedChange={checked => handleSwitchChange(option.id, checked)}
           />

--- a/src/components/SwitchGroup/src/SwitchGroup.tsx
+++ b/src/components/SwitchGroup/src/SwitchGroup.tsx
@@ -1,10 +1,16 @@
+import { useFormGroupLayout } from '@/hooks';
 import { cn } from '@/lib/utils';
 import React, { useCallback } from 'react';
 import { Switch } from '../../Switch';
 import { SwitchGroupProps } from '../types';
 
 const SwitchGroup = React.forwardRef<HTMLDivElement, SwitchGroupProps>(
-  ({ options, value, onChange, className, columns = 1, ...props }, ref) => {
+  (
+    { options, value, onChange, className, columns = 1, orientation = 'vertical', ...props },
+    ref,
+  ) => {
+    const layoutClasses = useFormGroupLayout({ orientation, columns });
+
     const handleSwitchChange = useCallback(
       (id: string, isChecked: boolean) => {
         const addId = (id: string) => onChange([...value, id]);
@@ -20,19 +26,17 @@ const SwitchGroup = React.forwardRef<HTMLDivElement, SwitchGroupProps>(
     );
 
     return (
-      <div ref={ref} className={cn('', className)} {...props}>
-        <div className={cn('grid gap-3', `grid-cols-${columns}`)}>
-          {options.map(option => (
-            <Switch
-              key={option.id}
-              id={option.id}
-              isChecked={value.includes(option.id)}
-              isDisabled={option.isDisabled}
-              label={option.label}
-              onCheckedChange={checked => handleSwitchChange(option.id, checked)}
-            />
-          ))}
-        </div>
+      <div ref={ref} className={cn(layoutClasses, className)} {...props}>
+        {options.map(option => (
+          <Switch
+            key={option.id}
+            id={option.id}
+            isChecked={value.includes(option.id)}
+            isDisabled={option.isDisabled}
+            label={option.label}
+            onCheckedChange={checked => handleSwitchChange(option.id, checked)}
+          />
+        ))}
       </div>
     );
   },

--- a/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
+++ b/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
@@ -1,11 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { SwitchGroup } from '../src/SwitchGroup';
 import { SwitchGroupDefault } from '../demos/SwitchGroupDefault';
+import { SwitchGroupHorizontal } from '../demos/SwitchGroupHorizontal';
+import { SwitchGroupVertical } from '../demos/SwitchGroupVertical';
 import { SwitchGroupWithSelection } from '../demos/SwitchGroupWithSelection';
 import { SwitchGroupSingleColumn } from '../demos/SwitchGroupSingleColumn';
 import { SwitchGroupThreeColumns } from '../demos/SwitchGroupThreeColumns';
 import { SwitchGroupWithManyOptions } from '../demos/SwitchGroupWithManyOptions';
 import sourceCodeDefault from '../demos/SwitchGroupDefault.tsx?raw';
+import sourceCodeHorizontal from '../demos/SwitchGroupHorizontal.tsx?raw';
+import sourceCodeVertical from '../demos/SwitchGroupVertical.tsx?raw';
 import sourceCodeWithSelection from '../demos/SwitchGroupWithSelection.tsx?raw';
 import sourceCodeSingleColumn from '../demos/SwitchGroupSingleColumn.tsx?raw';
 import sourceCodeThreeColumns from '../demos/SwitchGroupThreeColumns.tsx?raw';
@@ -37,10 +41,19 @@ const meta = {
       description: 'Array of switch options',
       type: { name: 'array', value: { name: 'object', value: {} }, required: true },
     },
+    orientation: {
+      control: 'radio',
+      options: ['horizontal', 'vertical'],
+      description: 'Layout orientation of the switch group',
+      type: { name: 'string', required: false },
+      table: {
+        type: { summary: 'horizontal | vertical' },
+      },
+    },
     columns: {
       control: 'radio',
       options: [1, 2, 3, 4],
-      description: 'Number of columns in the grid',
+      description: 'Number of columns in the grid (only applies when orientation is vertical)',
       type: { name: 'number', required: false },
     },
   },
@@ -80,6 +93,50 @@ export const Default: Story = {
     docs: {
       source: {
         code: sourceCodeDefault,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+/**
+ * SwitchGroup with horizontal layout.
+ * Shows switches arranged in a horizontal line.
+ */
+export const Horizontal: Story = {
+  render: () => <SwitchGroupHorizontal />,
+  args: {
+    options,
+    value: [],
+    onChange: () => {},
+    orientation: 'horizontal',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeHorizontal,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+/**
+ * SwitchGroup with vertical layout.
+ * Shows switches stacked vertically in one column.
+ */
+export const Vertical: Story = {
+  render: () => <SwitchGroupVertical />,
+  args: {
+    options,
+    value: [],
+    onChange: () => {},
+    orientation: 'vertical',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeVertical,
         language: 'tsx',
       },
     },

--- a/src/components/SwitchGroup/types.ts
+++ b/src/components/SwitchGroup/types.ts
@@ -10,6 +10,7 @@ export interface SwitchGroupProps extends Omit<HTMLAttributes<HTMLDivElement>, '
   options: SwitchOption[];
   value: string[];
   className?: string;
+  isDisabled?: boolean;
   columns?: 1 | 2 | 3 | 4;
   orientation?: 'horizontal' | 'vertical';
   onChange: (value: string[]) => void;

--- a/src/components/SwitchGroup/types.ts
+++ b/src/components/SwitchGroup/types.ts
@@ -11,5 +11,6 @@ export interface SwitchGroupProps extends Omit<HTMLAttributes<HTMLDivElement>, '
   value: string[];
   className?: string;
   columns?: 1 | 2 | 3 | 4;
+  orientation?: 'horizontal' | 'vertical';
   onChange: (value: string[]) => void;
 }

--- a/src/components/Tabs/demos/TabsWithDisabledTab.tsx
+++ b/src/components/Tabs/demos/TabsWithDisabledTab.tsx
@@ -9,7 +9,7 @@ export const TabsWithDisabledTab = ({
   <Tabs className="w-md" defaultValue={defaultValue} value={value} {...args}>
     <TabsList>
       <TabsTrigger value="active">Active Tab</TabsTrigger>
-      <TabsTrigger disabled value="disabled">
+      <TabsTrigger isDisabled value="disabled">
         Disabled Tab
       </TabsTrigger>
     </TabsList>

--- a/src/components/Tabs/src/Tabs.tsx
+++ b/src/components/Tabs/src/Tabs.tsx
@@ -1,3 +1,4 @@
+import { useAriaDisabled } from '@/hooks';
 import { styles } from '@/lib/styles';
 import { cn } from '@/lib/utils';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
@@ -27,21 +28,24 @@ TabsList.displayName = TabsPrimitive.List.displayName;
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   TabsTriggerProps
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      styles.focusRing,
-      `inline-flex items-center justify-center whitespace-nowrap rounded px-3 py-1.5 text-sm
-      font-bold ring-offset-background transition-all hover:bg-primary-200 hover:text-primary
-      disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50
-      aria-disabled:cursor-not-allowed aria-disabled:opacity-50 data-[state=active]:bg-primary
-      data-[state=active]:text-white`,
-      className,
-    )}
-    {...props}
-  />
-));
+>(({ className, isDisabled, ...props }, ref) => {
+  const disabledProps = useAriaDisabled({ isDisabled });
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        styles.focusRing,
+        `inline-flex items-center justify-center whitespace-nowrap rounded px-3 py-1.5 text-sm
+        font-bold ring-offset-background transition-all hover:bg-primary-200 hover:text-primary
+        aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50
+        data-[state=active]:bg-primary data-[state=active]:text-white`,
+        className,
+      )}
+      {...props}
+      {...disabledProps}
+    />
+  );
+});
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<

--- a/src/components/Tabs/types.ts
+++ b/src/components/Tabs/types.ts
@@ -13,5 +13,8 @@ export interface TabsProps extends ComponentPropsWithoutRef<typeof TabsPrimitive
 }
 
 export type TabsListProps = ComponentPropsWithoutRef<typeof TabsPrimitive.List>;
-export type TabsTriggerProps = ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>;
+export interface TabsTriggerProps
+  extends Omit<ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>, 'disabled'> {
+  isDisabled?: boolean;
+}
 export type TabsContentProps = ComponentPropsWithoutRef<typeof TabsPrimitive.Content>;


### PR DESCRIPTION
### Type

- [X] Chore

### Description

  - **RadioGroup** — removed native disabled prop from public type; added isDisabled prop wired through to each Radio child                                                                     
  - **Switch** — replaced duplicated inline validation with shared validateFormControlProps utility
  - **DropdownButton** — added zIndex prop; replaced hardcoded z-50 with getZIndex('dropdown', zIndex) to match other overlay components                                                        
  - **TabsTrigger** — added isDisabled prop + useAriaDisabled; removed native disabled from public type; swapped disabled: Tailwind classes for aria-disabled: equivalents                      
  - **SwitchGroup** — fixed dynamic grid-cols-${columns} class (purged at build time) by switching to useFormGroupLayout; added orientation prop matching CheckboxGroup/RadioGroup; added       
  Horizontal and Vertical Storybook stories and demos                                                                                                                                       
  - **Breadcrumbs** — added aria-current="page" to the current page <span>                                                                                                                      
  - **SingleSelect** / **SingleSelectProps** — added @deprecated JSDoc so IDEs surface a warning when used                                                                                          
  - **CheckboxOption** / **RadioOption** — added per-item isDisabled                                                                                                                                
  - **CheckboxGroup** / **SwitchGroup** — added group-level isDisabled prop; child disabled state is isDisabled || option.isDisabled, consistent with RadioGroup  