### PR TITLE
Chore: Docs props updates

### DIFF
--- a/src/components/FormItem/src/FormItem.test.tsx
+++ b/src/components/FormItem/src/FormItem.test.tsx
@@ -36,6 +36,26 @@ describe('FormItem', () => {
     );
   });
 
+  it('sets aria-invalid on the child when errorText is provided', () => {
+    render(
+      <FormItem elementId="test-input" errorText="Error text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid when errorText is not provided', () => {
+    render(
+      <FormItem elementId="test-input" hintText="Hint text" label="Label">
+        <input id="test-input" />
+      </FormItem>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).not.toHaveAttribute('aria-invalid');
+  });
+
   it('does not set aria-describedby when neither hintText nor errorText is provided', () => {
     render(
       <FormItem elementId="test-input" label="Label">

--- a/src/components/FormItem/src/FormItem.tsx
+++ b/src/components/FormItem/src/FormItem.tsx
@@ -43,9 +43,12 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
         .filter(Boolean)
         .join(' ') || undefined;
 
-    const child = describedByIds
-      ? React.cloneElement(children, { 'aria-describedby': describedByIds })
-      : children;
+    const childProps: Record<string, unknown> = {};
+    if (describedByIds) childProps['aria-describedby'] = describedByIds;
+    if (errorText) childProps['aria-invalid'] = true;
+
+    const child =
+      Object.keys(childProps).length > 0 ? React.cloneElement(children, childProps) : children;
 
     return (
       <div

--- a/src/components/FormItem/stories/FormItem.stories.tsx
+++ b/src/components/FormItem/stories/FormItem.stories.tsx
@@ -44,7 +44,8 @@ const meta = {
     },
     hintText: {
       control: 'text',
-      description: 'Hint text to display below the label and above the form element.',
+      description:
+        'Hint text to display below the label and above the form element. When provided, FormItem automatically injects `aria-describedby` pointing to the hint element into the child form control.',
       table: {
         type: {
           summary: 'string',
@@ -54,7 +55,7 @@ const meta = {
     errorText: {
       control: 'text',
       description:
-        'Error text to display below the form element. If provided, the form item will be styled to indicate an error.',
+        'Error text to display below the form element. When provided, FormItem automatically injects `aria-invalid="true"` and `aria-describedby` pointing to the error element into the child form control, so screen readers announce the error without any additional wiring.',
       table: {
         type: {
           summary: 'string',

--- a/src/components/Input/stories/Input.stories.tsx
+++ b/src/components/Input/stories/Input.stories.tsx
@@ -56,6 +56,14 @@ const meta = {
         },
       },
     },
+    required: {
+      control: 'boolean',
+      description:
+        'Marks the input as required for form validation. The form cannot be submitted without a value, and screen readers will announce the field as required.',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
     className: {
       type: 'string',
       description: 'Additional class names to apply to the input',

--- a/src/components/RadioGroup/stories/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/stories/RadioGroup.stories.tsx
@@ -95,6 +95,14 @@ const meta = {
         'Number of columns for default and tile variants (only applies when orientation is vertical). Defaults to 1.',
       type: { name: 'number', required: false },
     },
+    required: {
+      control: 'boolean',
+      description:
+        'Marks the group as required for form validation. Sets `aria-required` on the group root and `required` on the underlying hidden inputs so screen readers announce it and the form cannot be submitted without a selection.',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof RadioGroup>;

--- a/src/components/Textarea/stories/Textarea.stories.tsx
+++ b/src/components/Textarea/stories/Textarea.stories.tsx
@@ -61,6 +61,14 @@ const meta = {
         },
       },
     },
+    required: {
+      control: 'boolean',
+      description:
+        'Marks the textarea as required for form validation. The form cannot be submitted without a value, and screen readers will announce the field as required.',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
     className: {
       type: 'string',
       description: 'Additional class names to apply to the textarea',


### PR DESCRIPTION
### Type

- [X] Chore

### Description

- Ensure `aria-invalid` is set on FormItem children if there is an error
- Updated docs for injected props by FormItem -- `aria-invalid` and `aria-describedby`
- Ensure `required` prop is listed for all form components in the docs

### Screenshots

<img width="1075" height="903" alt="image" src="https://github.com/user-attachments/assets/fcb26a07-75ff-4eaf-8826-635d7da8af3f" />