### PR TITLE
Fix: ensure we refresh the Image when the 'src' changes

### DIFF
--- a/src/components/Image/src/Image.test.tsx
+++ b/src/components/Image/src/Image.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Image } from './Image';
+
+describe('Image', () => {
+  describe('Rendering', () => {
+    it('renders with src and alt', () => {
+      render(<Image alt="Example" src="https://example.com/image.jpg" />);
+      const img = screen.getByRole('img', { name: 'Example' });
+      expect(img).toHaveAttribute('src', 'https://example.com/image.jpg');
+    });
+  });
+
+  describe('Fallback behavior', () => {
+    it('shows the fallback when the src fails to load', () => {
+      render(
+        <Image
+          alt="Example"
+          fallback="https://example.com/fallback.jpg"
+          src="https://example.com/broken.jpg"
+        />,
+      );
+      const img = screen.getByRole('img', { name: 'Example' });
+
+      fireEvent.error(img);
+
+      expect(img).toHaveAttribute('src', 'https://example.com/fallback.jpg');
+    });
+
+    it('shows a newly valid src after a previous src failed instead of keeping the fallback', () => {
+      const { rerender } = render(
+        <Image
+          alt="Example"
+          fallback="https://example.com/fallback.jpg"
+          src="https://example.com/broken.jpg"
+        />,
+      );
+      const img = screen.getByRole('img', { name: 'Example' });
+
+      // The initial src fails, so the fallback is displayed.
+      fireEvent.error(img);
+      expect(img).toHaveAttribute('src', 'https://example.com/fallback.jpg');
+
+      // Updating to a valid src should reset the error state and show it.
+      rerender(
+        <Image
+          alt="Example"
+          fallback="https://example.com/fallback.jpg"
+          src="https://example.com/valid.jpg"
+        />,
+      );
+      expect(img).toHaveAttribute('src', 'https://example.com/valid.jpg');
+    });
+
+    it('falls back again if the updated src also fails', () => {
+      const { rerender } = render(
+        <Image
+          alt="Example"
+          fallback="https://example.com/fallback.jpg"
+          src="https://example.com/broken.jpg"
+        />,
+      );
+      const img = screen.getByRole('img', { name: 'Example' });
+
+      fireEvent.error(img);
+      rerender(
+        <Image
+          alt="Example"
+          fallback="https://example.com/fallback.jpg"
+          src="https://example.com/broken-2.jpg"
+        />,
+      );
+      expect(img).toHaveAttribute('src', 'https://example.com/broken-2.jpg');
+
+      fireEvent.error(img);
+      expect(img).toHaveAttribute('src', 'https://example.com/fallback.jpg');
+    });
+  });
+
+  describe('Callbacks', () => {
+    it('calls onError when the image fails to load', () => {
+      const handleError = vi.fn();
+      render(<Image alt="Example" src="https://example.com/broken.jpg" onError={handleError} />);
+      const img = screen.getByRole('img', { name: 'Example' });
+
+      fireEvent.error(img);
+
+      expect(handleError).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/Image/src/Image.tsx
+++ b/src/components/Image/src/Image.tsx
@@ -1,11 +1,18 @@
 import { cn } from '@/lib/utils';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ImageProps } from '../types';
 
 const Image = React.forwardRef<HTMLImageElement, ImageProps>(
   ({ src, alt, fallback, isLazy = true, shape = 'square', className, onError, ...props }, ref) => {
     const [hasError, setHasError] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
+
+    // Reset error/loading state when the src changes so a newly valid src is
+    // shown instead of continuing to display the fallback.
+    useEffect(() => {
+      setHasError(false);
+      setIsLoading(true);
+    }, [src]);
 
     const handleError = (evt: React.SyntheticEvent<HTMLImageElement, Event>) => {
       setHasError(true);


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Ensure we handle 'src' updates in the Image component
- When 'src' changes, reset the error and loading states so that we try to load/render the new image