### PR TITLE
Fix: Ensure error state from FormItem is reflected in the component

### DIFF
--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -180,6 +180,7 @@ function AutocompleteInner<T>(
               !value && 'text-muted-foreground',
               className,
             )}
+            data-component="autocomplete"
             isDisabled={isDisabled}
             variant="input"
             {...props}

--- a/src/components/Combobox/src/Combobox.test.tsx
+++ b/src/components/Combobox/src/Combobox.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
-import { Autocomplete } from './Autocomplete';
+import { Combobox } from './Combobox';
 
 const options = [
   { value: 'react', label: 'React' },
@@ -15,9 +15,7 @@ const options = [
 const Fixture = ({ initialValue = '' }: { initialValue?: string }) => {
   const [value, setValue] = useState(initialValue);
   return (
-    <Autocomplete
-      getOptionLabel={o => o.label}
-      getOptionValue={o => o.value}
+    <Combobox
       options={options}
       placeholder="Select a framework..."
       value={value}
@@ -26,7 +24,7 @@ const Fixture = ({ initialValue = '' }: { initialValue?: string }) => {
   );
 };
 
-describe('Autocomplete', () => {
+describe('Combobox', () => {
   describe('Accessibility', () => {
     it('has no violations when empty', async () => {
       const { container } = render(<Fixture />);
@@ -42,7 +40,7 @@ describe('Autocomplete', () => {
   });
 
   // The error-border styling in components.css targets the trigger via
-  // `button[data-component="autocomplete"]`, so this attribute must remain
+  // `button[data-component="combobox"]`, so this attribute must remain
   // present for the red border to show inside a FormItem with errorText.
   it('renders a trigger with the data-component selector used for error styling', () => {
     const { container } = render(
@@ -52,6 +50,6 @@ describe('Autocomplete', () => {
     );
 
     expect(container.querySelector('[data-error="true"]')).not.toBeNull();
-    expect(container.querySelector('button[data-component="autocomplete"]')).not.toBeNull();
+    expect(container.querySelector('button[data-component="combobox"]')).not.toBeNull();
   });
 });

--- a/src/components/Combobox/src/Combobox.tsx
+++ b/src/components/Combobox/src/Combobox.tsx
@@ -65,6 +65,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
                 !value && 'text-muted-foreground',
                 className,
               )}
+              data-component="combobox"
               isDisabled={isDisabled}
               variant="input"
               {...props}

--- a/src/components/FormItem/stories/FormItem.stories.tsx
+++ b/src/components/FormItem/stories/FormItem.stories.tsx
@@ -1,5 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Autocomplete } from '../../Autocomplete';
+import { Combobox } from '../../Combobox';
+import { DatePicker } from '../../DatePicker';
+import { DateRangePicker } from '../../DateRangePicker';
 import { Input } from '../../Input';
+import { MultiSelect } from '../../MultiSelect';
+import { Select } from '../../Select';
+// import { TagInput } from '../../TagInput'; // TagInput is not officially deployed yet
+import { Textarea } from '../../Textarea';
 import { FormItemRequiredWithLabelSlot } from '../demos/FormItemRequiredWithLabelSlot';
 import sourceCodeRequiredWithLabelSlot from '../demos/FormItemRequiredWithLabelSlot.tsx?raw';
 import { FormItemWithLabelSlot } from '../demos/FormItemWithLabelSlot';
@@ -182,4 +191,142 @@ export const RequiredWithLabelSlot: Story = {
       },
     },
   },
+};
+
+/* ------------------------------------------------------------------ *
+ * Error-state gallery: pick a control and see how it renders inside a
+ * FormItem with `errorText`. When FormItem has an error, it stamps
+ * `data-error="true"` on its wrapper and the library CSS paints the
+ * control's border in the destructive color. This story exercises every
+ * control that supports that error border, so it also guards against a
+ * control silently losing the treatment.
+ * ------------------------------------------------------------------ */
+
+const errorOptions = [
+  { value: 'react', label: 'React' },
+  { value: 'vue', label: 'Vue' },
+  { value: 'svelte', label: 'Svelte' },
+];
+
+type ErrorControlName =
+  | 'input'
+  | 'textarea'
+  | 'select'
+  | 'autocomplete'
+  | 'combobox'
+  | 'multiSelect'
+  // | 'tagInput' // TagInput is not officially deployed yet
+  | 'datePicker'
+  | 'dateRangePicker';
+
+const ERROR_CONTROL_LABELS: Record<ErrorControlName, string> = {
+  input: 'Input',
+  textarea: 'Textarea',
+  select: 'Select',
+  autocomplete: 'Autocomplete',
+  combobox: 'Combobox',
+  multiSelect: 'MultiSelect',
+  // tagInput: 'TagInput', // TagInput is not officially deployed yet
+  datePicker: 'DatePicker',
+  dateRangePicker: 'DateRangePicker',
+};
+
+/** Renders the selected form control with its own local state. */
+const ErrorControl = ({ control }: { control: ErrorControlName }) => {
+  const [text, setText] = useState('');
+  const [single, setSingle] = useState('');
+  const [multi, setMulti] = useState<string[]>([]);
+  // const [tags, setTags] = useState<{ id: string; text: string }[]>([]); // TagInput is not officially deployed yet
+  const [date, setDate] = useState<Date | undefined>();
+  const [range, setRange] = useState<{ from?: Date; to?: Date }>({});
+
+  switch (control) {
+    case 'input':
+      return (
+        <Input placeholder="Enter a value" value={text} onChange={e => setText(e.target.value)} />
+      );
+    case 'textarea':
+      return (
+        <Textarea
+          placeholder="Enter a value"
+          value={text}
+          onChange={e => setText(e.target.value)}
+        />
+      );
+    case 'select':
+      return <Select options={errorOptions} value={single} onChange={setSingle} />;
+    case 'autocomplete':
+      return (
+        <Autocomplete
+          getOptionLabel={o => o.label}
+          getOptionValue={o => o.value}
+          options={errorOptions}
+          value={single}
+          onChange={setSingle}
+        />
+      );
+    case 'combobox':
+      return <Combobox options={errorOptions} value={single} onChange={setSingle} />;
+    case 'multiSelect':
+      return <MultiSelect options={errorOptions} value={multi} onChange={setMulti} />;
+    // TagInput is not officially deployed yet
+    // case 'tagInput':
+    //   return <TagInput value={tags} onChange={setTags} />;
+    case 'datePicker':
+      return <DatePicker value={date} onChange={setDate} />;
+    case 'dateRangePicker':
+      return <DateRangePicker value={range} onChange={setRange} />;
+  }
+};
+
+/**
+ * In-canvas playground: a Combobox picks the control, which then renders inside
+ * a FormItem with an error so you can eyeball its destructive-colored border.
+ */
+const ErrorStatePlayground = () => {
+  const [selected, setSelected] = useState<ErrorControlName>('autocomplete');
+
+  const componentOptions = (Object.keys(ERROR_CONTROL_LABELS) as ErrorControlName[]).map(key => ({
+    value: key,
+    label: ERROR_CONTROL_LABELS[key],
+  }));
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem', maxWidth: 360 }}>
+      <FormItem
+        elementId="error-state-picker"
+        hintText="Choose a control to preview its error state"
+        label="Component"
+      >
+        <Combobox
+          options={componentOptions}
+          placeholder="Select a component..."
+          value={selected}
+          // Combobox clears when the current value is re-selected; keep the last
+          // valid selection so a control is always shown.
+          onChange={value => value && setSelected(value as ErrorControlName)}
+        />
+      </FormItem>
+
+      <FormItem
+        elementId={`error-state-${selected}`}
+        errorText="This field is required"
+        label={ERROR_CONTROL_LABELS[selected]}
+      >
+        <ErrorControl control={selected} />
+      </FormItem>
+    </div>
+  );
+};
+
+/**
+ * Pick a control from the in-canvas **Component** combobox to see how it looks
+ * inside a FormItem with an error. Every control here should show a
+ * destructive-colored border while the error is present.
+ */
+export const ErrorStateByControl: Story = {
+  name: 'Error State (by control)',
+  args: { children: <Input /> },
+  parameters: { controls: { disable: true } },
+  render: () => <ErrorStatePlayground />,
 };

--- a/src/components/MultiSelect/src/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/src/MultiSelect.test.tsx
@@ -1,3 +1,4 @@
+import { FormItem } from '@/components/FormItem';
 import { expectNoViolations } from '@/test/utils';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -33,6 +34,20 @@ const Fixture = ({ initialValue = [] }: FixtureProps) => {
 const getTrigger = () => document.querySelector('[aria-haspopup="listbox"]') as HTMLElement;
 
 describe('MultiSelect', () => {
+  // The error-border styling in components.css targets the trigger via
+  // `[data-component="multi-select"]`, so this attribute must remain present
+  // for the red border to show inside a FormItem with errorText.
+  it('renders a trigger with the data-component selector used for error styling', () => {
+    const { container } = render(
+      <FormItem elementId="frameworks" errorText="Required">
+        <Fixture />
+      </FormItem>,
+    );
+
+    expect(container.querySelector('[data-error="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-component="multi-select"]')).not.toBeNull();
+  });
+
   describe('Rendering', () => {
     it('renders the placeholder when no options are selected', () => {
       render(<Fixture />);

--- a/src/components/MultiSelect/src/MultiSelect.tsx
+++ b/src/components/MultiSelect/src/MultiSelect.tsx
@@ -177,6 +177,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
                 'flex h-auto min-h-[2.5rem] w-full items-stretch justify-between px-3 py-1.5',
                 className,
               )}
+              data-component="multi-select"
               role="button"
               tabIndex={0}
               onClick={evt => {

--- a/src/components/TagInput/src/TagInput.test.tsx
+++ b/src/components/TagInput/src/TagInput.test.tsx
@@ -1,0 +1,41 @@
+import { FormItem } from '@/components/FormItem';
+import { expectNoViolations } from '@/test/utils';
+import { render } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { TagInput } from './TagInput';
+import { Tag } from '../types';
+
+const Fixture = ({ initialValue = [] }: { initialValue?: Tag[] }) => {
+  const [value, setValue] = useState<Tag[]>(initialValue);
+  return <TagInput placeholder="Add tags..." value={value} onChange={setValue} />;
+};
+
+describe('TagInput', () => {
+  describe('Accessibility', () => {
+    it('has no violations when empty', async () => {
+      const { container } = render(
+        <FormItem elementId="tags" label="Tags">
+          <Fixture />
+        </FormItem>,
+      );
+      const results = await axe(container);
+      expectNoViolations(results);
+    });
+  });
+
+  // The error-border styling in components.css targets the bordered wrapper
+  // via `[data-component="tag-input"]`, so this attribute must remain present
+  // for the red border to show inside a FormItem with errorText.
+  it('renders a wrapper with the data-component selector used for error styling', () => {
+    const { container } = render(
+      <FormItem elementId="tags" errorText="Required">
+        <Fixture />
+      </FormItem>,
+    );
+
+    expect(container.querySelector('[data-error="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-component="tag-input"]')).not.toBeNull();
+  });
+});

--- a/src/components/TagInput/src/TagInput.tsx
+++ b/src/components/TagInput/src/TagInput.tsx
@@ -163,6 +163,7 @@ const TagInput = React.forwardRef<HTMLDivElement, TagInputProps>(
             isDisabled && 'cursor-not-allowed',
             className,
           )}
+          data-component="tag-input"
           {...props}
           onClick={handleContainerClick}
         >

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -8,8 +8,16 @@
 
   [data-error="true"] select,
   [data-error="true"] button[role="combobox"],
+  [data-error="true"] button[data-component="autocomplete"],
+  [data-error="true"] button[data-component="combobox"],
   [data-error="true"] button[data-component="date-picker"],
-  [data-error="true"] button[data-component="date-range-picker"] {
+  [data-error="true"] button[data-component="date-range-picker"],
+  [data-error="true"] [data-component="multi-select"] {
     @apply border-destructive focus:ring-destructive;
+  }
+
+  /* TagInput's bordered wrapper is a div using a focus-within ring. */
+  [data-error="true"] [data-component="tag-input"] {
+    @apply border-destructive focus-within:ring-destructive;
   }
 }


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Ensure all child for item components accurately reflect the error state of the FormItem
- Includes fixes for Autocomplete, Combobox, DatePicker and DateRangePicker and MultiSelect

### Screenshots

#### Autocomplete

<img width="460" height="438" alt="image" src="https://github.com/user-attachments/assets/0d192c31-eb1c-469f-9cb2-297b697d5787" />

#### Combobox

<img width="470" height="452" alt="image" src="https://github.com/user-attachments/assets/521e2de4-f09a-49b5-aaac-d863e522c942" />
