### PR TITLE
Fix: Read selected value back to screen readers on value-trigger controls (508)

### DIFF
--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -88,4 +88,49 @@ describe('Autocomplete', () => {
       expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
     });
   });
+
+  // When wrapped in a labeled FormItem, the trigger's associated <label for> would
+  // otherwise override its text content as the accessible name, so the selected value
+  // would never be read back. The trigger composes label + value via aria-labelledby.
+  describe('Accessible name', () => {
+    const LabeledFixture = ({ initialValue = 'react' }: { initialValue?: string }) => {
+      const [value, setValue] = useState(initialValue);
+      return (
+        <FormItem elementId="framework" label="Framework">
+          <Autocomplete
+            getOptionLabel={o => o.label}
+            getOptionValue={o => o.value}
+            id="framework"
+            options={options}
+            value={value}
+            onChange={setValue}
+          />
+        </FormItem>
+      );
+    };
+
+    it('reads back both the field label and the selected value', () => {
+      render(<LabeledFixture />);
+      // Accessible name is "Framework React" (label + value), so it matches both.
+      expect(screen.getByRole('button', { name: /Framework/ })).not.toBeNull();
+      expect(screen.getByRole('button', { name: /React/ })).not.toBeNull();
+      expect(screen.getByRole('button', { name: /Framework/ })).toBe(
+        screen.getByRole('button', { name: /React/ }),
+      );
+    });
+
+    it('falls back to the value when there is no associated label', () => {
+      render(
+        <Autocomplete
+          getOptionLabel={o => o.label}
+          getOptionValue={o => o.value}
+          options={options}
+          placeholder="Select a framework..."
+          value="vue"
+          onChange={() => {}}
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Vue' })).not.toBeNull();
+    });
+  });
 });

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -9,10 +9,12 @@ import {
   CommandLoading,
 } from '@/components/Command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/Popover';
+import { useComposedTriggerLabel } from '@/hooks';
 import { cn } from '@/lib/utils';
 import { getZIndex } from '@/lib/z-index';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Check, ChevronsUpDown, X } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { AutocompleteProps } from '../types';
 
 function AutocompleteInner<T>(
@@ -166,6 +168,17 @@ function AutocompleteInner<T>(
 
   const showClear = !isDisabled && Boolean(value || inputValue);
 
+  // Compose the trigger's accessible name from its associated label (e.g. from FormItem)
+  // plus the displayed value, so screen readers read back the current selection instead
+  // of only the field label. See useComposedTriggerLabel for the full rationale.
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const composedRef = useComposedRefs(ref, triggerRef);
+  const valueId = useId();
+  const triggerLabelledBy = useComposedTriggerLabel(triggerRef, valueId, {
+    'aria-label': props['aria-label'],
+    'aria-labelledby': props['aria-labelledby'],
+  });
+
   return (
     <>
       {name || required ? (
@@ -175,7 +188,7 @@ function AutocompleteInner<T>(
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <Button
-              ref={ref}
+              ref={composedRef}
               aria-expanded={open}
               autoFocus={autoFocus}
               className={cn(
@@ -187,6 +200,7 @@ function AutocompleteInner<T>(
               isDisabled={isDisabled}
               variant="input"
               {...props}
+              aria-labelledby={triggerLabelledBy}
               onKeyDown={e => {
                 if ((e.key === 'Delete' || e.key === 'Backspace') && value && !open) {
                   e.preventDefault();
@@ -195,7 +209,7 @@ function AutocompleteInner<T>(
                 props.onKeyDown?.(e);
               }}
             >
-              <span className="truncate">
+              <span className="truncate" id={valueId}>
                 {displayItem
                   ? renderValue
                     ? renderValue(displayItem)

--- a/src/components/Combobox/src/Combobox.test.tsx
+++ b/src/components/Combobox/src/Combobox.test.tsx
@@ -1,6 +1,6 @@
 import { FormItem } from '@/components/FormItem';
 import { expectNoViolations } from '@/test/utils';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -51,5 +51,40 @@ describe('Combobox', () => {
 
     expect(container.querySelector('[data-error="true"]')).not.toBeNull();
     expect(container.querySelector('button[data-component="combobox"]')).not.toBeNull();
+  });
+
+  // When wrapped in a labeled FormItem, the trigger's associated <label for> would
+  // otherwise override its text content as the accessible name, so the selected value
+  // would never be read back. The trigger composes label + value via aria-labelledby.
+  describe('Accessible name', () => {
+    const LabeledFixture = ({ initialValue = 'react' }: { initialValue?: string }) => {
+      const [value, setValue] = useState(initialValue);
+      return (
+        <FormItem elementId="framework" label="Framework">
+          <Combobox id="framework" options={options} value={value} onChange={setValue} />
+        </FormItem>
+      );
+    };
+
+    it('reads back both the field label and the selected value', () => {
+      render(<LabeledFixture />);
+      expect(screen.getByRole('button', { name: /Framework/ })).not.toBeNull();
+      expect(screen.getByRole('button', { name: /React/ })).not.toBeNull();
+      expect(screen.getByRole('button', { name: /Framework/ })).toBe(
+        screen.getByRole('button', { name: /React/ }),
+      );
+    });
+
+    it('falls back to the value when there is no associated label', () => {
+      render(
+        <Combobox
+          options={options}
+          placeholder="Select a framework..."
+          value="vue"
+          onChange={() => {}}
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Vue' })).not.toBeNull();
+    });
   });
 });

--- a/src/components/Combobox/src/Combobox.tsx
+++ b/src/components/Combobox/src/Combobox.tsx
@@ -8,10 +8,12 @@ import {
   CommandList,
 } from '@/components/Command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/Popover';
+import { useComposedTriggerLabel } from '@/hooks';
 import { cn } from '@/lib/utils';
 import { getZIndex } from '@/lib/z-index';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Check, ChevronsUpDown } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useId, useRef, useState } from 'react';
 import { ComboboxProps } from '../types';
 
 /** Default filter: case-insensitive substring match on label and value (like Autocomplete). */
@@ -49,6 +51,17 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
     const [open, setOpen] = useState(false);
     const resolvedZIndex = getZIndex('dropdown', zIndex);
 
+    // Compose the trigger's accessible name from its associated label (e.g. from FormItem)
+    // plus the displayed value, so screen readers read back the current selection instead
+    // of only the field label. See useComposedTriggerLabel for the full rationale.
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const composedRef = useComposedRefs(ref, triggerRef);
+    const valueId = useId();
+    const triggerLabelledBy = useComposedTriggerLabel(triggerRef, valueId, {
+      'aria-label': props['aria-label'],
+      'aria-labelledby': props['aria-labelledby'],
+    });
+
     return (
       <>
         {name || required ? (
@@ -57,7 +70,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <Button
-              ref={ref}
+              ref={composedRef}
               aria-expanded={open}
               autoFocus={autoFocus}
               className={cn(
@@ -70,8 +83,9 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
               isDisabled={isDisabled}
               variant="input"
               {...props}
+              aria-labelledby={triggerLabelledBy}
             >
-              <span className="min-w-0 truncate">
+              <span className="min-w-0 truncate" id={valueId}>
                 {value ? options.find(option => option.value === value)?.label : placeholder}
               </span>
               <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />

--- a/src/components/DatePicker/src/DatePicker.test.tsx
+++ b/src/components/DatePicker/src/DatePicker.test.tsx
@@ -1,0 +1,41 @@
+import { FormItem } from '@/components/FormItem';
+import { expectNoViolations } from '@/test/utils';
+import { render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { DatePicker } from './DatePicker';
+
+const LabeledFixture = () => {
+  const [value, setValue] = useState<Date | undefined>(new Date(2026, 0, 15));
+  return (
+    <FormItem elementId="start" label="Start date">
+      <DatePicker id="start" value={value} onChange={setValue} />
+    </FormItem>
+  );
+};
+
+describe('DatePicker', () => {
+  describe('Accessibility', () => {
+    it('has no violations with a selected date', async () => {
+      const { container } = render(<LabeledFixture />);
+      expectNoViolations(await axe(container));
+    });
+  });
+
+  // When wrapped in a labeled FormItem, the trigger's associated <label for> would
+  // otherwise override its text content as the accessible name, so the selected date
+  // would never be read back. The trigger composes label + value via aria-labelledby.
+  describe('Accessible name', () => {
+    it('reads back both the field label and the selected date', () => {
+      render(<LabeledFixture />);
+      const trigger = screen.getByRole('button', { name: /Start date/ });
+      expect(trigger).toBe(screen.getByRole('button', { name: /January 15, 2026/ }));
+    });
+
+    it('falls back to the value when there is no associated label', () => {
+      render(<DatePicker value={new Date(2026, 0, 15)} onChange={() => {}} />);
+      expect(screen.getByRole('button', { name: /January 15, 2026/ })).not.toBeNull();
+    });
+  });
+});

--- a/src/components/DatePicker/src/DatePicker.tsx
+++ b/src/components/DatePicker/src/DatePicker.tsx
@@ -1,11 +1,13 @@
 import { Button } from '@/components/Button';
 import { Calendar } from '@/components/Calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/Popover';
+import { useComposedTriggerLabel } from '@/hooks';
 import { cn } from '@/lib/utils';
 import { getZIndex } from '@/lib/z-index';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { format } from 'date-fns';
 import { Calendar as CalendarIcon } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useId, useRef, useState } from 'react';
 import { DatePickerProps } from '../types';
 
 const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
@@ -29,6 +31,16 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
     const [open, setOpen] = useState(false);
     const resolvedZIndex = getZIndex('popover', zIndex);
 
+    // Compose the trigger's accessible name from its associated label plus the displayed
+    // date, so screen readers read back the selection. See useComposedTriggerLabel.
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const composedRef = useComposedRefs(ref, triggerRef);
+    const valueId = useId();
+    const triggerLabelledBy = useComposedTriggerLabel(triggerRef, valueId, {
+      'aria-label': props['aria-label'],
+      'aria-labelledby': props['aria-labelledby'],
+    });
+
     const handleDateSelect = (date?: Date) => {
       onChange(date);
       setOpen(false);
@@ -47,7 +59,7 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <Button
-              ref={ref}
+              ref={composedRef}
               aria-required={required}
               autoFocus={autoFocus}
               className={cn(
@@ -60,9 +72,10 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
               isDisabled={isDisabled}
               variant="input"
               {...props}
+              aria-labelledby={triggerLabelledBy}
             >
               <CalendarIcon className="mr-2 h-4 w-4" />
-              {value ? format(value, 'LLLL dd, y') : <span>{placeholder}</span>}
+              <span id={valueId}>{value ? format(value, 'LLLL dd, y') : placeholder}</span>
             </Button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-auto px-0 py-0" zIndex={resolvedZIndex}>

--- a/src/components/DateRangePicker/src/DateRangePicker.test.tsx
+++ b/src/components/DateRangePicker/src/DateRangePicker.test.tsx
@@ -1,0 +1,50 @@
+import { FormItem } from '@/components/FormItem';
+import { expectNoViolations } from '@/test/utils';
+import { render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { DateRangePicker } from './DateRangePicker';
+
+const LabeledFixture = () => {
+  const [value, setValue] = useState<{ from?: Date; to?: Date }>({
+    from: new Date(2026, 0, 1),
+    to: new Date(2026, 0, 5),
+  });
+  return (
+    <FormItem elementId="range" label="Trip dates">
+      <DateRangePicker id="range" value={value} onChange={setValue} />
+    </FormItem>
+  );
+};
+
+describe('DateRangePicker', () => {
+  describe('Accessibility', () => {
+    it('has no violations with a selected range', async () => {
+      const { container } = render(<LabeledFixture />);
+      expectNoViolations(await axe(container));
+    });
+  });
+
+  // When wrapped in a labeled FormItem, the trigger's associated <label for> would
+  // otherwise override its text content as the accessible name, so the selected range
+  // would never be read back. The trigger composes label + value via aria-labelledby.
+  describe('Accessible name', () => {
+    it('reads back both the field label and the selected range', () => {
+      render(<LabeledFixture />);
+      const trigger = screen.getByRole('button', { name: /Trip dates/ });
+      expect(trigger).toBe(screen.getByRole('button', { name: /January 01, 2026/ }));
+      expect(trigger).toHaveAccessibleName(/January 05, 2026/);
+    });
+
+    it('falls back to the value when there is no associated label', () => {
+      render(
+        <DateRangePicker
+          value={{ from: new Date(2026, 0, 1), to: new Date(2026, 0, 5) }}
+          onChange={() => {}}
+        />,
+      );
+      expect(screen.getByRole('button', { name: /January 01, 2026/ })).not.toBeNull();
+    });
+  });
+});

--- a/src/components/DateRangePicker/src/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/src/DateRangePicker.tsx
@@ -1,8 +1,11 @@
+import { useComposedTriggerLabel } from '@/hooks';
 import { cn } from '@/lib/utils';
 import { getZIndex } from '@/lib/z-index';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { format } from 'date-fns';
 import { Calendar as CalendarIcon } from 'lucide-react';
 import * as React from 'react';
+import { useId, useRef } from 'react';
 import { Button } from '../../Button';
 import { Calendar } from '../../Calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '../../Popover';
@@ -30,6 +33,16 @@ const DateRangePicker = React.forwardRef<HTMLButtonElement, DateRangePickerProps
     ref,
   ) => {
     const resolvedZIndex = getZIndex('popover', zIndex);
+
+    // Compose the trigger's accessible name from its associated label plus the displayed
+    // range, so screen readers read back the selection. See useComposedTriggerLabel.
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const composedRef = useComposedRefs(ref, triggerRef);
+    const valueId = useId();
+    const triggerLabelledBy = useComposedTriggerLabel(triggerRef, valueId, {
+      'aria-label': props['aria-label'],
+      'aria-labelledby': props['aria-labelledby'],
+    });
 
     const handleDayClick = (day: Date) => {
       const { from, to } = value;
@@ -65,7 +78,7 @@ const DateRangePicker = React.forwardRef<HTMLButtonElement, DateRangePickerProps
         <Popover>
           <PopoverTrigger asChild>
             <Button
-              ref={ref}
+              ref={composedRef}
               autoFocus={autoFocus}
               className={cn(
                 'w-full justify-start px-3 text-left font-normal',
@@ -75,21 +88,24 @@ const DateRangePicker = React.forwardRef<HTMLButtonElement, DateRangePickerProps
               isDisabled={isDisabled}
               variant="input"
               {...props}
+              aria-labelledby={triggerLabelledBy}
             >
               <CalendarIcon className="mr-2 h-4 w-4" />
-              {(() => {
-                if (value.from) {
-                  if (value.to) {
-                    return (
-                      <>
-                        {format(value.from, 'LLLL dd, y')} - {format(value.to, 'LLLL dd, y')}
-                      </>
-                    );
+              <span id={valueId}>
+                {(() => {
+                  if (value.from) {
+                    if (value.to) {
+                      return (
+                        <>
+                          {format(value.from, 'LLLL dd, y')} - {format(value.to, 'LLLL dd, y')}
+                        </>
+                      );
+                    }
+                    return format(value.from, 'LLLL dd, y');
                   }
-                  return format(value.from, 'LLLL dd, y');
-                }
-                return <span>{placeholder.from}</span>;
-              })()}
+                  return placeholder.from;
+                })()}
+              </span>
             </Button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-auto px-0 py-0" zIndex={resolvedZIndex}>

--- a/src/components/MultiSelect/src/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/src/MultiSelect.test.tsx
@@ -410,4 +410,30 @@ describe('MultiSelect', () => {
       expect(getTrigger()).toHaveAttribute('aria-haspopup', 'listbox');
     });
   });
+
+  // The trigger is a <div role="button">, which is not labelable, so a FormItem
+  // <label for> would otherwise be orphaned (label never announced). The trigger
+  // composes label + selected values via aria-labelledby so both are read back.
+  describe('Accessible name', () => {
+    const LabeledFixture = ({ initialValue = ['react'] }: FixtureProps) => {
+      const [value, setValue] = useState(initialValue);
+      return (
+        <FormItem elementId="frameworks" label="Frameworks">
+          <MultiSelect id="frameworks" options={options} value={value} onChange={setValue} />
+        </FormItem>
+      );
+    };
+
+    it('reads back both the field label and the selected values', () => {
+      render(<LabeledFixture />);
+      const trigger = screen.getByRole('button', { name: /Frameworks/ });
+      expect(trigger).toBe(getTrigger());
+      expect(trigger).toHaveAccessibleName(/React/);
+    });
+
+    it('falls back to the selected values when there is no associated label', () => {
+      render(<Fixture initialValue={['react']} />);
+      expect(getTrigger()).toHaveAccessibleName(/React/);
+    });
+  });
 });

--- a/src/components/MultiSelect/src/MultiSelect.tsx
+++ b/src/components/MultiSelect/src/MultiSelect.tsx
@@ -1,9 +1,9 @@
-import { useAriaDisabled } from '@/hooks';
+import { useAriaDisabled, useComposedTriggerLabel } from '@/hooks';
 import { styles } from '@/lib/styles';
 import { cn } from '@/lib/utils';
 import { getZIndex } from '@/lib/z-index';
 import { Check, ChevronsUpDown, X } from 'lucide-react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { buttonVariants } from '../../Button/constants';
 import {
   Command,
@@ -43,6 +43,16 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
     const disabledProps = useAriaDisabled({ isDisabled });
     const triggerRef = useRef<HTMLDivElement | null>(null);
     const removeButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+    // The trigger is a <div role="button">, which is not labelable — so a FormItem
+    // <label for> would otherwise be orphaned (label not announced). Compose the trigger's
+    // accessible name from its associated label plus the selected values so screen readers
+    // announce both. See useComposedTriggerLabel.
+    const valueId = useId();
+    const triggerLabelledBy = useComposedTriggerLabel(triggerRef, valueId, {
+      'aria-label': props['aria-label'],
+      'aria-labelledby': props['aria-labelledby'],
+    });
 
     // Handle autoFocus
     useEffect(() => {
@@ -190,8 +200,11 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
               onKeyDown={handleTriggerKeyDown}
               {...disabledProps}
               {...props}
+              aria-labelledby={triggerLabelledBy}
             >
-              <div className="flex flex-1 text-left">{renderTriggerContent()}</div>
+              <div className="flex flex-1 text-left" id={valueId}>
+                {renderTriggerContent()}
+              </div>
               <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 self-center opacity-50" />
             </div>
           </PopoverTrigger>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useAriaDisabled';
 export * from './useAriaLabelled';
+export * from './useComposedTriggerLabel';
 export * from './useFormGroupLayout';

--- a/src/hooks/useComposedTriggerLabel.ts
+++ b/src/hooks/useComposedTriggerLabel.ts
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+export type UseComposedTriggerLabelOptions = {
+  /** A consumer-supplied aria-label, if any. When present it provides the whole name. */
+  'aria-label'?: string;
+  /** A consumer-supplied aria-labelledby, if any. The value id is appended to it. */
+  'aria-labelledby'?: string;
+};
+
+/**
+ * Composes an `aria-labelledby` for a button-style trigger whose accessible name must
+ * combine an associated external `<label>` with the trigger's displayed value.
+ *
+ * A native `<label for>` (e.g. the one FormItem renders) becomes a `<button>`'s accessible
+ * name and *overrides* its text content, so the value shown in the trigger ("John Doe")
+ * gets dropped from the accessibility tree and is never read back. Given a ref to the
+ * trigger and the id of the element that holds the value, this returns an `aria-labelledby`
+ * listing the associated label id(s) followed by the value id, so screen readers announce
+ * "Label, Value".
+ *
+ * Returns `undefined` when the trigger has no associated label and no consumer-supplied
+ * `aria-labelledby` — letting the accessible name fall back to the trigger's content
+ * (which is the value), so an unlabeled trigger still reads correctly.
+ *
+ * Known gap — a bare `aria-label`: when the consumer supplies an `aria-label` (a plain
+ * string, with no associated `<label>` or `aria-labelledby`), it becomes the entire
+ * accessible name and the value is NOT appended, so the selection is not read back. This
+ * is a deliberate decision: we respect the consumer's explicit `aria-label` rather than
+ * override it, and it is not a regression (a bare `aria-label` already overrode the
+ * trigger's content before this hook existed). It could be closed by rendering a
+ * visually-hidden element holding the label text and composing it with the value id, at
+ * the cost of an extra DOM node; we opted not to since a bare `aria-label` on a
+ * select-style trigger is uncommon. Prefer a visible label (via FormItem, a `<label for>`,
+ * or `aria-labelledby`) to get the value read back.
+ *
+ * @param triggerRef - Ref to the trigger element. Works with labelable elements (`<button>`,
+ *   via `.labels`) and non-labelable triggers like `<div role="button">` (matched by id
+ *   against `<label for>`); the latter must carry an `id` for its label to be found.
+ * @param valueId - Id of the element rendering the current value.
+ * @param options - Consumer-supplied aria-label / aria-labelledby to respect.
+ */
+export function useComposedTriggerLabel(
+  triggerRef: React.RefObject<HTMLElement | null>,
+  valueId: string,
+  {
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+  }: UseComposedTriggerLabelOptions = {},
+): string | undefined {
+  // Seed with the consumer value so SSR / first paint has a sensible name; the effect
+  // refines it once the DOM (and any associated label) is available.
+  const [labelledBy, setLabelledBy] = useState<string | undefined>(ariaLabelledBy);
+
+  useEffect(() => {
+    // An explicit aria-label provides the entire accessible name; don't compose.
+    if (ariaLabel) {
+      setLabelledBy(undefined);
+      return;
+    }
+
+    // A consumer-supplied aria-labelledby wins for the label portion; append the value.
+    if (ariaLabelledBy) {
+      setLabelledBy(`${ariaLabelledBy} ${valueId}`);
+      return;
+    }
+
+    const el = triggerRef.current;
+    if (!el) {
+      setLabelledBy(undefined);
+      return;
+    }
+
+    // Prefer the native `.labels` collection (labelable elements like <button>). For a
+    // non-labelable trigger such as a `<div role="button">` (MultiSelect), a `<label for>`
+    // never associates, so fall back to finding it by the trigger's id.
+    const nativeLabels = (el as HTMLButtonElement).labels;
+    let labels: HTMLElement[] =
+      nativeLabels && nativeLabels.length > 0 ? Array.from(nativeLabels) : [];
+    if (labels.length === 0 && el.id) {
+      labels = Array.from(el.ownerDocument.querySelectorAll('label')).filter(
+        label => (label as HTMLLabelElement).htmlFor === el.id,
+      );
+    }
+
+    if (labels.length === 0) {
+      // No associated label: fall back to the trigger's content (the value).
+      setLabelledBy(undefined);
+      return;
+    }
+
+    const labelIds = labels.map((label, index) => {
+      // Ensure every associated label can be referenced; only assign when missing so we
+      // never clobber an id a consumer set.
+      if (!label.id) label.id = `${valueId}-label-${index}`;
+      return label.id;
+    });
+
+    setLabelledBy(`${labelIds.join(' ')} ${valueId}`);
+  }, [triggerRef, valueId, ariaLabel, ariaLabelledBy]);
+
+  return labelledBy;
+}


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- Value-trigger controls (Autocomplete, Combobox, DatePicker, DateRangePicker, MultiSelect) render the current selection as the trigger's text content. When wrapped in a labeled FormItem, the associated <label for> becomes the trigger's accessible name and overrides that content, so screen readers announce only the field label (e.g. "User") and never read back the selection ("John Doe").
- Add a shared useComposedTriggerLabel hook that composes the trigger's accessible name from its associated label plus the displayed value via aria-labelledby, so AT announces "Label, Value". It detects labels for both <button> triggers (via .labels) and non-labelable <div role="button"> triggers (via `label[for]`), and falls back to the trigger content when there is no associated label. MultiSelect had the inverse bug — its `<div role="button">` made the FormItem label orphaned — which the same hook resolves.
- Select is intentionally excluded: its Radix trigger keeps role="combobox", which already announces name (label) and value (content) separately, so composing the value into the name would double-announce it.
- Documents the deliberate bare-aria-label gap in the hook. TagInput (a different editable-input pattern) is left for a separate follow-up.