### PR TITLE
Fix: Clear Image loading skeleton when src changes (gray box)

### DIFF
--- a/src/components/Image/demos/ImageChangingSrc.tsx
+++ b/src/components/Image/demos/ImageChangingSrc.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { Button } from '../../Button';
+import { Image } from '../src/Image';
+
+const landscapeSrc = 'https://images.pexels.com/photos/2014422/pexels-photo-2014422.jpeg';
+const gradientSrc = 'https://images.pexels.com/photos/1526/dark-blur-blurred-gradient.jpg';
+
+/**
+ * Demonstrates changing the `src` at runtime. The image starts with an empty src and can
+ * be swapped between two URLs; the loading skeleton clears once the new image loads
+ * instead of getting stuck. A cache-busting query param is appended so the skeleton is
+ * visible on each change.
+ */
+export const ImageChangingSrc = () => {
+  const [src, setSrc] = useState('');
+  const load = (url: string) => setSrc(`${url}?v=${Date.now()}`);
+
+  return (
+    <div className="space-y-4">
+      <Image alt="Runtime src change demo" height={400} src={src} width={800} />
+      <div className="flex flex-wrap gap-2">
+        <Button variant="ghost" onClick={() => setSrc('')}>
+          Set empty src
+        </Button>
+        <Button onClick={() => load(landscapeSrc)}>Load landscape</Button>
+        <Button onClick={() => load(gradientSrc)}>Load gradient</Button>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Current src: {src ? src.split('?')[0] : '(empty)'}
+      </p>
+    </div>
+  );
+};

--- a/src/components/Image/src/Image.test.tsx
+++ b/src/components/Image/src/Image.test.tsx
@@ -77,6 +77,37 @@ describe('Image', () => {
     });
   });
 
+  describe('Loading state', () => {
+    // The loading skeleton (the "gray box") is the .animate-pulse overlay.
+    const skeleton = (container: HTMLElement) => container.querySelector('.animate-pulse');
+
+    it('shows the skeleton while loading and hides it once the image loads', () => {
+      const { container } = render(<Image alt="Example" src="https://example.com/a.jpg" />);
+      const img = screen.getByRole('img', { name: 'Example' });
+
+      expect(skeleton(container)).not.toBeNull();
+      expect(img).toHaveClass('invisible');
+
+      fireEvent.load(img);
+
+      expect(skeleton(container)).toBeNull();
+      expect(img).not.toHaveClass('invisible');
+    });
+
+    it('re-shows then clears the skeleton when src changes and the new image loads', () => {
+      // Reproduces the reported flow: src starts as '' then becomes a valid src.
+      const { container, rerender } = render(<Image alt="Example" src="" />);
+      expect(skeleton(container)).not.toBeNull();
+
+      rerender(<Image alt="Example" src="https://example.com/valid.jpg" />);
+      // Still loading the newly-set src.
+      expect(skeleton(container)).not.toBeNull();
+
+      fireEvent.load(screen.getByRole('img', { name: 'Example' }));
+      expect(skeleton(container)).toBeNull();
+    });
+  });
+
   describe('Callbacks', () => {
     it('calls onError when the image fails to load', () => {
       const handleError = vi.fn();

--- a/src/components/Image/src/Image.tsx
+++ b/src/components/Image/src/Image.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { ImageProps } from '../types';
 
 const Image = React.forwardRef<HTMLImageElement, ImageProps>(
@@ -7,12 +7,18 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>(
     const [hasError, setHasError] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
 
-    // Reset error/loading state when the src changes so a newly valid src is
-    // shown instead of continuing to display the fallback.
-    useEffect(() => {
+    // Reset error/loading state when `src` changes, so a newly valid src is shown instead
+    // of continuing to display the fallback or a stale loading skeleton. This runs during
+    // render (React's "adjusting state when a prop changes" pattern) rather than in an
+    // effect: an effect runs asynchronously after commit and could re-set `isLoading` to
+    // true *after* the new image's load event already fired, leaving the skeleton (the
+    // "gray box") shown forever with no further load event to clear it.
+    const [trackedSrc, setTrackedSrc] = useState(src);
+    if (src !== trackedSrc) {
+      setTrackedSrc(src);
       setHasError(false);
       setIsLoading(true);
-    }, [src]);
+    }
 
     const handleError = (evt: React.SyntheticEvent<HTMLImageElement, Event>) => {
       setHasError(true);

--- a/src/components/Image/src/Image.tsx
+++ b/src/components/Image/src/Image.tsx
@@ -10,7 +10,7 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>(
     // Reset error/loading state when `src` changes, so a newly valid src is shown instead
     // of continuing to display the fallback or a stale loading skeleton. This runs during
     // render (React's "adjusting state when a prop changes" pattern) rather than in an
-    // effect: an effect runs asynchronously after commit and could re-set `isLoading` to
+    // effect: an effect runs asynchronously after commit and could reset `isLoading` to
     // true *after* the new image's load event already fired, leaving the skeleton (the
     // "gray box") shown forever with no further load event to clear it.
     const [trackedSrc, setTrackedSrc] = useState(src);

--- a/src/components/Image/stories/Image.stories.tsx
+++ b/src/components/Image/stories/Image.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { ImageChangingSrc } from '../demos/ImageChangingSrc';
+import sourceCodeChangingSrc from '../demos/ImageChangingSrc.tsx?raw';
 import { Image } from '../src/Image';
 
 const meta = {
@@ -164,5 +166,29 @@ export const CustomStyle: Story = {
     width: 400,
     height: 300,
     className: 'rounded-lg shadow-lg',
+  },
+};
+
+/**
+ * Changing the `src` at runtime resets the loading state and shows the new image.
+ *
+ * This covers the case where `src` starts empty (or is swapped for another URL) and is
+ * then set to a valid image: the loading skeleton clears once the new image loads instead
+ * of getting stuck. Use the buttons to set an empty src, load an image, or swap between
+ * two images.
+ */
+export const ChangingSrc: Story = {
+  render: () => <ImageChangingSrc />,
+  args: {
+    src: '',
+    alt: 'Runtime src change demo',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeChangingSrc,
+        language: 'tsx',
+      },
+    },
   },
 };


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description

- The src-change reset added recently ran in a useEffect, which fires asynchronously after commit. When src went from '' to a valid URL, the new image's load event could set isLoading=false before the effect ran, and the effect would then flip it back to true — with no further load event to clear it, leaving the loading skeleton (a "gray box") shown forever.

- Reset loading/error state during render (React's "adjusting state when a prop changes" pattern) instead of in an effect, so it can no longer overwrite a load that already completed. The fallback-reset-on-src-change behavior is preserved.

- Add a ChangingSrc story (demos/ImageChangingSrc.tsx) that swaps the src at runtime to exercise the empty -> valid and image -> image transitions, and tests covering the skeleton hiding on load and clearing after a src change.

### Testing

1. Navigate to http://localhost:6006/?path=/docs/data-display-image--docs#changing-src-1
2. Test changing the src back and forth

### Screenshots

<img width="1051" height="984" alt="image" src="https://github.com/user-attachments/assets/4255c97d-28f5-4ef9-b7a0-c8016611b0df" />
