### PR TITLE
Fix: Announce Autocomplete results and selection to screen readers (508)

### DIFF
--- a/src/components/Autocomplete/demos/AutocompleteAnnouncementDebug.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteAnnouncementDebug.tsx
@@ -115,7 +115,9 @@ export const AutocompleteAnnouncementDebug = () => {
           value={value}
           onChange={setValue}
         />
-        <p className="text-sm text-muted-foreground">
+        {/* aria-hidden so the screen reader hears only the Autocomplete's own
+            announcements, not this debug readout. */}
+        <p aria-hidden="true" className="text-sm text-muted-foreground">
           Selected value: <span className="font-medium">{value || 'none'}</span>
         </p>
       </div>

--- a/src/components/Autocomplete/demos/AutocompleteAnnouncementDebug.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteAnnouncementDebug.tsx
@@ -118,18 +118,20 @@ export const AutocompleteAnnouncementDebug = () => {
         <p className="text-sm text-muted-foreground">
           Selected value: <span className="font-medium">{value || 'none'}</span>
         </p>
+      </div>
 
+      <div aria-hidden="true" className="space-y-4">
         {/* Visible mirror of the live region. aria-hidden so it is NOT itself
-            announced — it only lets you see what the real region holds. */}
-        <div aria-hidden="true" className="bg-muted/40 rounded-md border p-3">
+            announced — it only lets you see what the real region holds. Kept to
+            the right of (and above the event log, not below) the autocomplete so
+            the open dropdown never covers it. */}
+        <div className="bg-muted/40 rounded-md border p-3">
           <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Current live-region text
           </div>
           <div className="min-h-6 font-mono text-sm">{liveText || '(empty)'}</div>
         </div>
-      </div>
 
-      <div aria-hidden="true" className="space-y-2">
         <div className="flex items-center justify-between">
           <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Event log (ms)

--- a/src/components/Autocomplete/demos/AutocompleteAnnouncementDebug.tsx
+++ b/src/components/Autocomplete/demos/AutocompleteAnnouncementDebug.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState } from 'react';
+import { Autocomplete } from '../src/Autocomplete';
+
+interface AutocompleteOption {
+  value: string;
+  label: string;
+}
+
+const options: AutocompleteOption[] = [
+  { value: 'react', label: 'React' },
+  { value: 'vue', label: 'Vue' },
+  { value: 'angular', label: 'Angular' },
+  { value: 'svelte', label: 'Svelte' },
+  { value: 'solid', label: 'Solid' },
+];
+
+interface LogEntry {
+  id: number;
+  at: number;
+  kind: 'announce' | 'focus';
+  text: string;
+}
+
+/**
+ * Debug harness for the Autocomplete's screen-reader announcements.
+ *
+ * It does NOT read the component's internal state. Instead it watches the real
+ * DOM — the same thing a screen reader consumes:
+ *   1. a MutationObserver on the visually-hidden `[role="status"][aria-live]`
+ *      live region, logging every text change (this is what would be spoken);
+ *   2. document `focusin` events, so we can see where focus lands relative to
+ *      an announcement (focus moving to the trigger can interrupt a polite
+ *      announcement in real screen readers).
+ *
+ * The live-region text is also mirrored into a visible (but aria-hidden) panel
+ * so you can literally see what is queued for the screen reader.
+ */
+export const AutocompleteAnnouncementDebug = () => {
+  const [value, setValue] = useState('');
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const [liveText, setLiveText] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const startRef = useRef<number>(performance.now());
+  const idRef = useRef(0);
+
+  const push = (kind: LogEntry['kind'], text: string) => {
+    setLog(prev => [
+      ...prev,
+      { id: idRef.current++, at: Math.round(performance.now() - startRef.current), kind, text },
+    ]);
+  };
+
+  // Watch the real live region for text changes — this is what a screen reader
+  // announces. Re-attach whenever the region node appears/changes.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let region: HTMLElement | null = null;
+    let regionObserver: MutationObserver | null = null;
+
+    const readRegion = () => {
+      if (!region) return;
+      const text = region.textContent ?? '';
+      setLiveText(text);
+      if (text.trim().length > 0) push('announce', text);
+    };
+
+    const attach = () => {
+      const found = container.querySelector<HTMLElement>('[role="status"][aria-live]');
+      if (found && found !== region) {
+        region = found;
+        regionObserver?.disconnect();
+        regionObserver = new MutationObserver(readRegion);
+        regionObserver.observe(region, { childList: true, characterData: true, subtree: true });
+        readRegion();
+      }
+    };
+
+    // The live region is always mounted, but re-attach defensively if the tree
+    // changes (e.g. the popover opening/closing re-renders siblings).
+    const treeObserver = new MutationObserver(attach);
+    treeObserver.observe(container, { childList: true, subtree: true });
+    attach();
+
+    return () => {
+      treeObserver.disconnect();
+      regionObserver?.disconnect();
+    };
+  }, []);
+
+  // Track focus moves so we can correlate them with announcements.
+  useEffect(() => {
+    const onFocus = (e: FocusEvent) => {
+      const el = e.target as HTMLElement | null;
+      if (!el || el === document.body) return;
+      const label =
+        el.getAttribute('aria-label') ||
+        el.textContent?.trim().slice(0, 60) ||
+        el.tagName.toLowerCase();
+      push('focus', `${el.tagName.toLowerCase()}: "${label}"`);
+    };
+    document.addEventListener('focusin', onFocus);
+    return () => document.removeEventListener('focusin', onFocus);
+  }, []);
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2" style={{ maxWidth: 720 }}>
+      <div ref={containerRef} className="space-y-3">
+        <Autocomplete<AutocompleteOption>
+          getOptionLabel={o => o.label}
+          getOptionValue={o => o.value}
+          options={options}
+          placeholder="Select a framework..."
+          value={value}
+          onChange={setValue}
+        />
+        <p className="text-sm text-muted-foreground">
+          Selected value: <span className="font-medium">{value || 'none'}</span>
+        </p>
+
+        {/* Visible mirror of the live region. aria-hidden so it is NOT itself
+            announced — it only lets you see what the real region holds. */}
+        <div aria-hidden="true" className="bg-muted/40 rounded-md border p-3">
+          <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Current live-region text
+          </div>
+          <div className="min-h-6 font-mono text-sm">{liveText || '(empty)'}</div>
+        </div>
+      </div>
+
+      <div aria-hidden="true" className="space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Event log (ms)
+          </div>
+          <button
+            className="rounded border px-2 py-0.5 text-xs hover:bg-muted"
+            type="button"
+            onClick={() => setLog([])}
+          >
+            Clear
+          </button>
+        </div>
+        <ol className="max-h-80 space-y-1 overflow-y-auto rounded-md border p-2 font-mono text-xs">
+          {log.length === 0 ? (
+            <li className="text-muted-foreground">
+              No events yet — open the list, type, and select an option.
+            </li>
+          ) : (
+            log.map(entry => (
+              <li
+                key={entry.id}
+                className={entry.kind === 'announce' ? 'text-foreground' : 'text-muted-foreground'}
+              >
+                <span className="tabular-nums">{String(entry.at).padStart(5, ' ')}ms</span>{' '}
+                <span className="font-semibold">
+                  {entry.kind === 'announce' ? '📢 announce' : '🎯 focus  '}
+                </span>{' '}
+                {entry.text}
+              </li>
+            ))
+          )}
+        </ol>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -1,6 +1,6 @@
 import { FormItem } from '@/components/FormItem';
 import { expectNoViolations } from '@/test/utils';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
@@ -86,6 +86,61 @@ describe('Autocomplete', () => {
 
       expect(trigger()).toHaveTextContent('Select a framework...');
       expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+    });
+  });
+
+  // 508: screen readers only speak options via aria-activedescendant while
+  // arrowing through the list. A single result (nothing to arrow to), an empty
+  // result set, and the final selection would otherwise pass silently, so the
+  // component announces those states through visually-hidden live regions.
+  describe('Screen reader announcements', () => {
+    const openTrigger = async (user: ReturnType<typeof userEvent.setup>) => {
+      await user.click(screen.getByRole('button', { name: /select a framework/i }));
+    };
+
+    it('announces the number of available results when the list opens', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+
+      const statuses = screen.getAllByRole('status');
+      expect(statuses.some(node => node.textContent === '3 results available')).toBe(true);
+    });
+
+    it('announces a single result using the singular form', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+      await user.type(screen.getByPlaceholderText('Select a framework...'), 'ang');
+
+      const statuses = screen.getAllByRole('status');
+      await waitFor(() =>
+        expect(statuses.some(node => node.textContent === '1 result available')).toBe(true),
+      );
+    });
+
+    it('announces when a search returns no results', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+      await user.type(screen.getByPlaceholderText('Select a framework...'), 'zzz');
+
+      const statuses = screen.getAllByRole('status');
+      await waitFor(() =>
+        expect(statuses.some(node => node.textContent === 'No results found')).toBe(true),
+      );
+    });
+
+    it('announces the selected value after choosing an option', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+      await user.click(screen.getByRole('option', { name: /vue/i }));
+
+      const statuses = screen.getAllByRole('status');
+      await waitFor(() =>
+        expect(statuses.some(node => node.textContent === 'Vue selected')).toBe(true),
+      );
     });
   });
 });

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -41,18 +41,44 @@ describe('Autocomplete', () => {
       expectNoViolations(results);
     });
 
-    // 508: a screen reader focusing the trigger should hear that the text is the
-    // current selection, not just the label on its own.
-    it('exposes the selection as "<label>, selected" in the trigger accessible name', () => {
+    // 508: with no associated label the trigger's accessible name falls back to
+    // its content — the value plus a visually-hidden "selected" so a screen
+    // reader conveys that the text is the current selection.
+    it('exposes the value and "selected" in the trigger accessible name', () => {
       const { container } = render(<Fixture initialValue="react" />);
       const trigger = container.querySelector('button[data-component="autocomplete"]');
-      expect(trigger).toHaveAccessibleName('React, selected');
+      expect(trigger).toHaveAccessibleName('React selected');
     });
 
     it('does not add "selected" to the trigger when nothing is chosen', () => {
       const { container } = render(<Fixture />);
       const trigger = container.querySelector('button[data-component="autocomplete"]');
       expect(trigger).toHaveAccessibleName('Select a framework...');
+    });
+
+    // When wrapped in a labeled FormItem, a native <label for> would otherwise
+    // become the whole accessible name of the <button> and drop the value. The
+    // trigger composes label + value + "selected" via aria-labelledby so a
+    // screen reader reads back the field label AND the current selection.
+    it('reads back the field label, the value, and "selected" when labeled', () => {
+      const LabeledFixture = () => {
+        const [value, setValue] = useState('react');
+        return (
+          <FormItem elementId="framework" label="Framework">
+            <Autocomplete
+              getOptionLabel={o => o.label}
+              getOptionValue={o => o.value}
+              id="framework"
+              options={options}
+              value={value}
+              onChange={setValue}
+            />
+          </FormItem>
+        );
+      };
+      render(<LabeledFixture />);
+      const trigger = screen.getByRole('button', { name: 'Framework React selected' });
+      expect(trigger).not.toBeNull();
     });
   });
 

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -246,5 +246,62 @@ describe('Autocomplete', () => {
 
       await waitFor(() => expect(trigger()).toHaveTextContent('Vue'));
     });
+
+    // 508 (audit #4): distinguish the committed selection from a merely
+    // highlighted option, in both the announcement and the option's own name.
+    it('announces the current selection when navigating onto the chosen option', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<Fixture initialValue="vue" />);
+      await user.click(container.querySelector('button[data-component="autocomplete"]')!);
+
+      await user.keyboard('{ArrowDown}'); // React (not chosen)
+      await announced('React, selected');
+      await user.keyboard('{ArrowDown}'); // Vue (the chosen value)
+      await announced('Vue, selected, current selection');
+    });
+
+    it('exposes the chosen option in the list to assistive tech', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<Fixture initialValue="vue" />);
+      await user.click(container.querySelector('button[data-component="autocomplete"]')!);
+
+      expect(screen.getByRole('option', { name: 'Vue (current selection)' })).not.toBeNull();
+      expect(screen.getByRole('option', { name: 'React' })).not.toBeNull();
+    });
+  });
+
+  // 508 (audit #2, #3): combobox semantics on the trigger and a labeled search
+  // field.
+  describe('Combobox semantics', () => {
+    it('marks the trigger as opening a listbox popup', () => {
+      const { container } = render(<Fixture />);
+      const trigger = container.querySelector('button[data-component="autocomplete"]');
+      expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    });
+
+    it('opens the list when ArrowDown is pressed on the trigger', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<Fixture />);
+      const trigger = container.querySelector<HTMLButtonElement>(
+        'button[data-component="autocomplete"]',
+      )!;
+      trigger.focus();
+
+      expect(screen.queryByPlaceholderText('Select a framework...')).toBeNull();
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() =>
+        expect(screen.getByPlaceholderText('Select a framework...')).toBeInTheDocument(),
+      );
+    });
+
+    it('gives the search input a programmatic label, not just a placeholder', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<Fixture />);
+      await user.click(container.querySelector('button[data-component="autocomplete"]')!);
+
+      expect(screen.getByPlaceholderText('Select a framework...')).toHaveAccessibleName(
+        'Select a framework...',
+      );
+    });
   });
 });

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -87,6 +87,18 @@ describe('Autocomplete', () => {
       expect(trigger()).toHaveTextContent('Select a framework...');
       expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
     });
+
+    // 508: clearing removes the clear button from the DOM, so focus must be
+    // returned to the trigger rather than falling to <body>.
+    it('moves focus to the trigger when the value is cleared', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<Fixture initialValue="react" />);
+      const trigger = container.querySelector('button[data-component="autocomplete"]');
+
+      await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+      await waitFor(() => expect(trigger).toHaveFocus());
+    });
   });
 
   // 508: screen readers only speak options via aria-activedescendant while

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -116,25 +116,25 @@ describe('Autocomplete', () => {
         expect(screen.getAllByRole('status').some(node => node.textContent === text)).toBe(true),
       );
 
-    it('announces the first (highlighted) option when the list opens', async () => {
+    it('announces the first (highlighted) option and its position when the list opens', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
 
-      await announced('React');
+      await announced('React, 1 of 3');
     });
 
-    it('announces each option as the highlight moves with the arrow keys', async () => {
+    it('announces each option and its position as the highlight moves with the arrow keys', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
-      await announced('React');
+      await announced('React, 1 of 3');
 
       await user.keyboard('{ArrowDown}');
-      await announced('Vue');
+      await announced('Vue, 2 of 3');
 
       await user.keyboard('{ArrowDown}');
-      await announced('Angular');
+      await announced('Angular, 3 of 3');
     });
 
     it('announces the sole option when a search narrows to a single result', async () => {
@@ -143,8 +143,9 @@ describe('Autocomplete', () => {
       await openTrigger(user);
       await user.type(screen.getByPlaceholderText('Select a framework...'), 'ang');
 
-      // Nothing to arrow to, but the lone option is auto-highlighted and read.
-      await announced('Angular');
+      // Nothing to arrow to, but the lone option is auto-highlighted and read,
+      // and the position conveys that it is the only result.
+      await announced('Angular, 1 of 1');
     });
 
     it('announces when a search returns no results', async () => {

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -101,37 +101,50 @@ describe('Autocomplete', () => {
     });
   });
 
-  // 508: screen readers only speak options via aria-activedescendant while
-  // arrowing through the list. A single result (nothing to arrow to), an empty
-  // result set, and the final selection would otherwise pass silently, so the
-  // component announces those states through visually-hidden live regions.
+  // 508: cmdk keeps the combobox aria-activedescendant in sync as the highlight
+  // moves, but VoiceOver does not reliably speak activedescendant changes, so
+  // the component mirrors the active option's label into a live region. States
+  // with no option to speak (empty result set) and the final selection are
+  // announced there too.
   describe('Screen reader announcements', () => {
     const openTrigger = async (user: ReturnType<typeof userEvent.setup>) => {
       await user.click(screen.getByRole('button', { name: /select a framework/i }));
     };
 
-    it('announces the number of available results when the list opens', async () => {
+    const announced = (text: string) =>
+      waitFor(() =>
+        expect(screen.getAllByRole('status').some(node => node.textContent === text)).toBe(true),
+      );
+
+    it('announces the first (highlighted) option when the list opens', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
 
-      await waitFor(() =>
-        expect(
-          screen.getAllByRole('status').some(node => node.textContent === '3 results available'),
-        ).toBe(true),
-      );
+      await announced('React');
     });
 
-    it('announces a single result using the singular form', async () => {
+    it('announces each option as the highlight moves with the arrow keys', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+      await announced('React');
+
+      await user.keyboard('{ArrowDown}');
+      await announced('Vue');
+
+      await user.keyboard('{ArrowDown}');
+      await announced('Angular');
+    });
+
+    it('announces the sole option when a search narrows to a single result', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
       await user.type(screen.getByPlaceholderText('Select a framework...'), 'ang');
 
-      const statuses = screen.getAllByRole('status');
-      await waitFor(() =>
-        expect(statuses.some(node => node.textContent === '1 result available')).toBe(true),
-      );
+      // Nothing to arrow to, but the lone option is auto-highlighted and read.
+      await announced('Angular');
     });
 
     it('announces when a search returns no results', async () => {
@@ -140,10 +153,7 @@ describe('Autocomplete', () => {
       await openTrigger(user);
       await user.type(screen.getByPlaceholderText('Select a framework...'), 'zzz');
 
-      const statuses = screen.getAllByRole('status');
-      await waitFor(() =>
-        expect(statuses.some(node => node.textContent === 'No results found')).toBe(true),
-      );
+      await announced('No results found');
     });
 
     it('announces the selected value after choosing an option', async () => {
@@ -152,10 +162,7 @@ describe('Autocomplete', () => {
       await openTrigger(user);
       await user.click(screen.getByRole('option', { name: /vue/i }));
 
-      const statuses = screen.getAllByRole('status');
-      await waitFor(() =>
-        expect(statuses.some(node => node.textContent === 'Vue selected')).toBe(true),
-      );
+      await announced('Vue selected');
     });
   });
 });

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -184,6 +184,22 @@ describe('Autocomplete', () => {
       await announced('Vue selected');
     });
 
+    // 508: options are nested inside a role="group", so without an explicit
+    // set size a screen reader announces "1 of 1" for every option. Each option
+    // must carry its position and the total.
+    it('gives each option an aria-posinset and aria-setsize for correct position', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+
+      const opts = await screen.findAllByRole('option');
+      expect(opts).toHaveLength(3);
+      opts.forEach((opt, i) => {
+        expect(opt).toHaveAttribute('aria-setsize', '3');
+        expect(opt).toHaveAttribute('aria-posinset', String(i + 1));
+      });
+    });
+
     // The active option is controlled so navigation can be announced; guard that
     // this did not break selecting an option by keyboard (arrow to it + Enter).
     it('selects the highlighted option when Enter is pressed', async () => {

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -131,19 +131,23 @@ describe('Autocomplete', () => {
         expect(screen.getAllByRole('status').some(node => node.textContent === text)).toBe(true),
       );
 
-    it('announces the suggestion count and browsing instructions when the list opens', async () => {
+    it('announces the count, instructions, and first suggestion when the list opens', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
 
-      await announced('There are 3 suggestions, use the up and down arrow keys to browse.');
+      await announced(
+        'There are 3 suggestions, use the up and down arrow keys to browse. React, 1 of 3.',
+      );
     });
 
     it('announces each option as it is highlighted with the arrow keys', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
-      await announced('There are 3 suggestions, use the up and down arrow keys to browse.');
+      await announced(
+        'There are 3 suggestions, use the up and down arrow keys to browse. React, 1 of 3.',
+      );
 
       // The first arrow press lands on the first option (nothing is
       // pre-highlighted), so no option is skipped.
@@ -157,13 +161,16 @@ describe('Autocomplete', () => {
       await announced('Angular, selected');
     });
 
-    it('uses the singular form when a search narrows to a single result', async () => {
+    it('reads the sole suggestion (singular) when a search narrows to one result', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
       await user.type(screen.getByPlaceholderText('Select a framework...'), 'ang');
 
-      await announced('There is 1 suggestion, use the up and down arrow keys to browse.');
+      // The single result's content is read even though the user has not arrowed.
+      await announced(
+        'There is 1 suggestion, use the up and down arrow keys to browse. Angular, 1 of 1.',
+      );
     });
 
     it('announces when a search returns no results', async () => {

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -187,6 +187,29 @@ describe('Autocomplete', () => {
       await announced('Angular, selected');
     });
 
+    // Regression: the list-status effect must not re-fire on navigation (its
+    // deps used to include the unstable displayOptions/accessors), which
+    // clobbered each "<option>, selected" with the count on every arrow.
+    it('does not re-announce the list status after navigating to an option', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+      await announced(
+        'There are 3 suggestions, use the up and down arrow keys to browse. React, 1 of 3.',
+      );
+
+      await user.keyboard('{ArrowDown}');
+      await announced('React, selected');
+
+      // The status region holds only the option announcement; it did not revert.
+      const status = screen
+        .getAllByRole('status')
+        .map(n => n.textContent)
+        .filter(Boolean)
+        .join('|');
+      expect(status).toBe('React, selected');
+    });
+
     it('reads the sole suggestion (singular) when a search narrows to one result', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
@@ -231,6 +254,18 @@ describe('Autocomplete', () => {
         expect(opt).toHaveAttribute('aria-setsize', '3');
         expect(opt).toHaveAttribute('aria-posinset', String(i + 1));
       });
+    });
+
+    // Regression: options must not be wrapped in a role="group" — a lone group
+    // makes some screen readers announce "1 of 1" (the group's position) on
+    // every option, overriding the per-option position.
+    it('does not wrap the options in a group', async () => {
+      const user = userEvent.setup();
+      render(<Fixture />);
+      await openTrigger(user);
+
+      await screen.findAllByRole('option');
+      expect(screen.queryByRole('group')).toBeNull();
     });
 
     // The active option is controlled so navigation can be announced; guard that

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -103,8 +103,9 @@ describe('Autocomplete', () => {
 
   // 508: cmdk keeps the combobox aria-activedescendant in sync as the highlight
   // moves, but VoiceOver does not reliably speak activedescendant changes, so
-  // the component mirrors the active option's label into a live region. States
-  // with no option to speak (empty result set) and the final selection are
+  // the component mirrors announcements into a live region: the suggestion count
+  // and how to browse when the list opens/changes, and the highlighted option as
+  // the user arrows. The empty-result message and the final selection are
   // announced there too.
   describe('Screen reader announcements', () => {
     const openTrigger = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -116,36 +117,39 @@ describe('Autocomplete', () => {
         expect(screen.getAllByRole('status').some(node => node.textContent === text)).toBe(true),
       );
 
-    it('announces the first (highlighted) option and its position when the list opens', async () => {
+    it('announces the suggestion count and browsing instructions when the list opens', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
 
-      await announced('React, 1 of 3');
+      await announced('There are 3 suggestions, use the up and down arrow keys to browse.');
     });
 
-    it('announces each option and its position as the highlight moves with the arrow keys', async () => {
+    it('announces each option as it is highlighted with the arrow keys', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
-      await announced('React, 1 of 3');
+      await announced('There are 3 suggestions, use the up and down arrow keys to browse.');
+
+      // The first arrow press lands on the first option (nothing is
+      // pre-highlighted), so no option is skipped.
+      await user.keyboard('{ArrowDown}');
+      await announced('React, selected');
 
       await user.keyboard('{ArrowDown}');
-      await announced('Vue, 2 of 3');
+      await announced('Vue, selected');
 
       await user.keyboard('{ArrowDown}');
-      await announced('Angular, 3 of 3');
+      await announced('Angular, selected');
     });
 
-    it('announces the sole option when a search narrows to a single result', async () => {
+    it('uses the singular form when a search narrows to a single result', async () => {
       const user = userEvent.setup();
       render(<Fixture />);
       await openTrigger(user);
       await user.type(screen.getByPlaceholderText('Select a framework...'), 'ang');
 
-      // Nothing to arrow to, but the lone option is auto-highlighted and read,
-      // and the position conveys that it is the only result.
-      await announced('Angular, 1 of 1');
+      await announced('There is 1 suggestion, use the up and down arrow keys to browse.');
     });
 
     it('announces when a search returns no results', async () => {
@@ -164,6 +168,20 @@ describe('Autocomplete', () => {
       await user.click(screen.getByRole('option', { name: /vue/i }));
 
       await announced('Vue selected');
+    });
+
+    // The active option is controlled so navigation can be announced; guard that
+    // this did not break selecting an option by keyboard (arrow to it + Enter).
+    it('selects the highlighted option when Enter is pressed', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<Fixture />);
+      const trigger = () => container.querySelector('button[data-component="autocomplete"]');
+
+      await openTrigger(user);
+      await user.keyboard('{ArrowDown}{ArrowDown}'); // React -> Vue
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => expect(trigger()).toHaveTextContent('Vue'));
     });
   });
 });

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -103,8 +103,11 @@ describe('Autocomplete', () => {
       render(<Fixture />);
       await openTrigger(user);
 
-      const statuses = screen.getAllByRole('status');
-      expect(statuses.some(node => node.textContent === '3 results available')).toBe(true);
+      await waitFor(() =>
+        expect(
+          screen.getAllByRole('status').some(node => node.textContent === '3 results available'),
+        ).toBe(true),
+      );
     });
 
     it('announces a single result using the singular form', async () => {

--- a/src/components/Autocomplete/src/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.test.tsx
@@ -40,6 +40,20 @@ describe('Autocomplete', () => {
       const results = await axe(container);
       expectNoViolations(results);
     });
+
+    // 508: a screen reader focusing the trigger should hear that the text is the
+    // current selection, not just the label on its own.
+    it('exposes the selection as "<label>, selected" in the trigger accessible name', () => {
+      const { container } = render(<Fixture initialValue="react" />);
+      const trigger = container.querySelector('button[data-component="autocomplete"]');
+      expect(trigger).toHaveAccessibleName('React, selected');
+    });
+
+    it('does not add "selected" to the trigger when nothing is chosen', () => {
+      const { container } = render(<Fixture />);
+      const trigger = container.querySelector('button[data-component="autocomplete"]');
+      expect(trigger).toHaveAccessibleName('Select a framework...');
+    });
   });
 
   // The error-border styling in components.css targets the trigger via

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -366,11 +366,14 @@ function AutocompleteInner<T>(
                   options, and some screen readers (VoiceOver) announce that lone
                   group's position ("1 of 1") on every option. Rendering the
                   options directly in the listbox keeps each option's own
-                  aria-posinset/aria-setsize the position that is read. The p-1
-                  on the list restores the inset the group used to provide, so
-                  options and the selected-row highlight don't touch the edges. */}
+                  aria-posinset/aria-setsize the position that is read. The
+                  px-1 py-1 on the list restores the inset the group used to
+                  provide (px-1 py-1, not the p-1 shorthand, so a consumer's
+                  listClassName padding can still override per-axis). */}
               {!loading && !error && displayOptions.length > 0 ? (
-                <CommandList className={cn('max-h-[16.5rem] overflow-y-auto p-1', listClassName)}>
+                <CommandList
+                  className={cn('max-h-[16.5rem] overflow-y-auto px-1 py-1', listClassName)}
+                >
                   {displayOptions.map((option, index) => {
                     const optValue = getOptionValueFn(option);
                     const isSelected = Boolean(optValue && value && optValue === value);

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -15,11 +15,6 @@ import { Check, ChevronsUpDown, X } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AutocompleteProps } from '../types';
 
-// Delay before the result-set status is announced to screen readers. Debounced
-// so a burst of typing queues only the final message (like a typeahead backend
-// query) instead of one announcement per keystroke.
-const ANNOUNCE_DEBOUNCE_MS = 500;
-
 function AutocompleteInner<T>(
   {
     loadOptions,
@@ -59,6 +54,10 @@ function AutocompleteInner<T>(
   const [selectedItem, setSelectedItem] = useState<T | undefined>(undefined);
   // Single message read out to screen readers via a polite live region.
   const [announcement, setAnnouncement] = useState('');
+  // The highlighted option in the open list. Controlled so cmdk fires
+  // onValueChange (it only does so when its value is controlled), which lets us
+  // announce the active option as the user navigates.
+  const [activeValue, setActiveValue] = useState('');
 
   // Debounce timer reference
   const debounceTimer = useRef<NodeJS.Timeout>();
@@ -187,41 +186,55 @@ function AutocompleteInner<T>(
 
   const showClear = !isDisabled && Boolean(value || inputValue);
 
-  // Announce the result-set status to screen readers when the list is open.
-  // Screen readers otherwise only speak items via aria-activedescendant while
-  // arrowing through the list, so a single result or an empty result set would
-  // pass silently. Debounced so a burst of typing queues only the final message
-  // rather than one announcement per keystroke. A selection announcement (set
-  // synchronously in handleSelect) is not clobbered here because this effect
-  // exits early once the list has closed.
+  const activeOption = useMemo(
+    () =>
+      activeValue
+        ? displayOptions.find(
+            opt => getOptionValueFn(opt).toLowerCase() === activeValue.toLowerCase(),
+          )
+        : undefined,
+    [activeValue, displayOptions, getOptionValueFn],
+  );
+
+  // Keep a valid option highlighted while the list is open so there is always
+  // something to announce (and so the single-result case has an active option).
+  // When the results change under a stale highlight, snap to the first option.
+  // Reset when the list closes.
+  useEffect(() => {
+    if (!open) {
+      setActiveValue('');
+      return;
+    }
+    if (displayOptions.length > 0 && !activeOption) {
+      setActiveValue(getOptionValueFn(displayOptions[0]));
+    }
+  }, [open, displayOptions, activeOption, getOptionValueFn]);
+
+  // Announce the active option as the highlight moves — cmdk keeps the combobox
+  // `aria-activedescendant` in sync, but VoiceOver does not reliably speak
+  // activedescendant changes on comboboxes, so we mirror the active option's
+  // label into the live region. States with no highlightable option (loading, a
+  // failed fetch, an empty result set) are announced in their place. A
+  // selection announcement (set in handleSelect) is left untouched because this
+  // effect exits once the list closes.
   useEffect(() => {
     if (!open) return;
-
-    const timer = setTimeout(() => {
-      if (loading) {
-        setAnnouncement(loadingMessage);
-      } else if (error) {
-        setAnnouncement(errorMessage);
-      } else if (hasSearched && displayOptions.length === 0) {
-        setAnnouncement(emptyMessage);
-      } else if (displayOptions.length > 0) {
-        const count = displayOptions.length;
-        setAnnouncement(`${count} ${count === 1 ? 'result' : 'results'} available`);
-      } else {
-        setAnnouncement('');
-      }
-    }, ANNOUNCE_DEBOUNCE_MS);
-
-    return () => clearTimeout(timer);
+    if (loading) setAnnouncement(loadingMessage);
+    else if (error) setAnnouncement(errorMessage);
+    else if (hasSearched && displayOptions.length === 0) setAnnouncement(emptyMessage);
+    else if (activeOption) setAnnouncement(getOptionLabel?.(activeOption) ?? activeValue);
   }, [
     open,
     loading,
     error,
     hasSearched,
     displayOptions.length,
+    activeOption,
+    activeValue,
     loadingMessage,
     errorMessage,
     emptyMessage,
+    getOptionLabel,
   ]);
 
   return (
@@ -271,7 +284,7 @@ function AutocompleteInner<T>(
             className={cn('min-w-[--radix-popover-trigger-width] px-0 py-0', popoverClassName)}
             zIndex={resolvedZIndex}
           >
-            <Command shouldFilter={false}>
+            <Command shouldFilter={false} value={activeValue} onValueChange={setActiveValue}>
               <CommandInput
                 placeholder={placeholder}
                 value={inputValue}

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -233,9 +233,11 @@ function AutocompleteInner<T>(
   }, [open]);
 
   // Announce the state of the suggestion list when it opens or the results
-  // change: the number of suggestions plus how to browse them, or the loading /
-  // error / empty-result message. Individual options are announced separately as
-  // the user navigates (handleActiveChange). This effect does not re-run on
+  // change: the number of suggestions, how to browse them, and the first
+  // suggestion (the option cmdk highlights) so its content is read even when the
+  // user has not arrowed yet — e.g. after filtering to a single result. Or the
+  // loading / error / empty-result message. Options are also announced as the
+  // user navigates (handleActiveChange). This effect does not re-run on
   // navigation (its deps do not include the active option) and exits once the
   // list closes, so it never clobbers an option or selection announcement.
   useEffect(() => {
@@ -245,8 +247,9 @@ function AutocompleteInner<T>(
     else if (displayOptions.length > 0) {
       const count = displayOptions.length;
       const suggestions = count === 1 ? '1 suggestion' : `${count} suggestions`;
+      const firstLabel = getOptionLabel?.(displayOptions[0]) ?? getOptionValueFn(displayOptions[0]);
       setAnnouncement(
-        `There ${count === 1 ? 'is' : 'are'} ${suggestions}, use the up and down arrow keys to browse.`,
+        `There ${count === 1 ? 'is' : 'are'} ${suggestions}, use the up and down arrow keys to browse. ${firstLabel}, 1 of ${count}.`,
       );
     } else if (hasSearched) {
       setAnnouncement(emptyMessage);
@@ -256,10 +259,12 @@ function AutocompleteInner<T>(
     loading,
     error,
     hasSearched,
-    displayOptions.length,
+    displayOptions,
     loadingMessage,
     errorMessage,
     emptyMessage,
+    getOptionLabel,
+    getOptionValueFn,
   ]);
 
   return (

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -345,6 +345,11 @@ function AutocompleteInner<T>(
                       return (
                         <CommandItem
                           key={optValue || index}
+                          // Options sit inside a nested role="group", so screen
+                          // readers cannot infer each one's position in the list
+                          // and announce "1 of 1". Set it explicitly.
+                          aria-posinset={index + 1}
+                          aria-setsize={displayOptions.length}
                           className="cursor-pointer"
                           value={optValue}
                           onSelect={handleSelect}

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -366,9 +366,11 @@ function AutocompleteInner<T>(
                   options, and some screen readers (VoiceOver) announce that lone
                   group's position ("1 of 1") on every option. Rendering the
                   options directly in the listbox keeps each option's own
-                  aria-posinset/aria-setsize the position that is read. */}
+                  aria-posinset/aria-setsize the position that is read. The p-1
+                  on the list restores the inset the group used to provide, so
+                  options and the selected-row highlight don't touch the edges. */}
               {!loading && !error && displayOptions.length > 0 ? (
-                <CommandList className={cn('max-h-[16.5rem] overflow-y-auto', listClassName)}>
+                <CommandList className={cn('max-h-[16.5rem] overflow-y-auto p-1', listClassName)}>
                   {displayOptions.map((option, index) => {
                     const optValue = getOptionValueFn(option);
                     const isSelected = Boolean(optValue && value && optValue === value);

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -210,25 +210,31 @@ function AutocompleteInner<T>(
     }
   }, [open, displayOptions, activeOption, getOptionValueFn]);
 
-  // Announce the active option as the highlight moves — cmdk keeps the combobox
-  // `aria-activedescendant` in sync, but VoiceOver does not reliably speak
-  // activedescendant changes on comboboxes, so we mirror the active option's
-  // label into the live region. States with no highlightable option (loading, a
-  // failed fetch, an empty result set) are announced in their place. A
-  // selection announcement (set in handleSelect) is left untouched because this
-  // effect exits once the list closes.
+  // Announce the active option, with its position, as the highlight moves —
+  // following the combobox pattern ("<label>, <n> of <total>"). cmdk keeps the
+  // combobox `aria-activedescendant` in sync, but VoiceOver does not reliably
+  // speak activedescendant changes on comboboxes, so we mirror the active option
+  // into the live region. The position also conveys the result count and how it
+  // changes as the list narrows. States with no highlightable option (loading, a
+  // failed fetch, an empty result set) are announced in their place. A selection
+  // announcement (set in handleSelect) is left untouched because this effect
+  // exits once the list closes.
   useEffect(() => {
     if (!open) return;
     if (loading) setAnnouncement(loadingMessage);
     else if (error) setAnnouncement(errorMessage);
     else if (hasSearched && displayOptions.length === 0) setAnnouncement(emptyMessage);
-    else if (activeOption) setAnnouncement(getOptionLabel?.(activeOption) ?? activeValue);
+    else if (activeOption) {
+      const label = getOptionLabel?.(activeOption) ?? activeValue;
+      const position = displayOptions.indexOf(activeOption) + 1;
+      setAnnouncement(`${label}, ${position} of ${displayOptions.length}`);
+    }
   }, [
     open,
     loading,
     error,
     hasSearched,
-    displayOptions.length,
+    displayOptions,
     activeOption,
     activeValue,
     loadingMessage,

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -196,6 +196,11 @@ function AutocompleteInner<T>(
 
   const showClear = !isDisabled && Boolean(value || inputValue);
 
+  // Label spoken when the trigger is focused. Appends ", selected" so a screen
+  // reader conveys that the text is the current selection, not just the value.
+  const selectedLabel = displayItem ? (getOptionLabel?.(displayItem) ?? value) : value;
+  const triggerAriaLabel = selectedLabel ? `${selectedLabel}, selected` : undefined;
+
   // Announce the highlighted option as the user arrows through the list. cmdk
   // keeps the combobox `aria-activedescendant` in sync, but VoiceOver does not
   // reliably speak activedescendant changes on comboboxes, so we mirror the
@@ -272,6 +277,7 @@ function AutocompleteInner<T>(
                 triggerRef.current = el;
               }}
               aria-expanded={open}
+              aria-label={triggerAriaLabel}
               autoFocus={autoFocus}
               className={cn(
                 'w-full justify-start px-3 text-left font-normal',

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -66,6 +66,13 @@ function AutocompleteInner<T>(
   // clear button is used.
   const triggerRef = useRef<HTMLButtonElement | null>(null);
 
+  // Whether the user has arrowed through the list since it opened / the results
+  // last changed. cmdk auto-highlights the first option (and fires
+  // onValueChange) on open, so this distinguishes that automatic highlight —
+  // which should announce the suggestion count + instructions — from real
+  // navigation, which announces the highlighted option.
+  const hasNavigatedRef = useRef(false);
+
   // Cleanup timer on unmount
   useEffect(() => {
     return () => {
@@ -151,6 +158,9 @@ function AutocompleteInner<T>(
   const handleInputChange = useCallback(
     (input: string) => {
       setInputValue(input);
+      // New search results are a fresh list; the next announcement should be the
+      // updated count + instructions, not a navigated option.
+      hasNavigatedRef.current = false;
 
       if (input.length === 0) {
         setHasSearched(false);
@@ -186,61 +196,65 @@ function AutocompleteInner<T>(
 
   const showClear = !isDisabled && Boolean(value || inputValue);
 
-  const activeOption = useMemo(
-    () =>
-      activeValue
-        ? displayOptions.find(
-            opt => getOptionValueFn(opt).toLowerCase() === activeValue.toLowerCase(),
-          )
-        : undefined,
-    [activeValue, displayOptions, getOptionValueFn],
+  // Announce the highlighted option as the user arrows through the list. cmdk
+  // keeps the combobox `aria-activedescendant` in sync, but VoiceOver does not
+  // reliably speak activedescendant changes on comboboxes, so we mirror the
+  // option into the live region. The automatic highlight cmdk applies on open is
+  // ignored here (hasNavigatedRef) so it does not pre-empt the count + how-to
+  // announcement; only genuine navigation speaks an option.
+  const handleActiveChange = useCallback(
+    (nextActive: string) => {
+      // Ignore cmdk's automatic highlight on open (no navigation yet); leaving
+      // the controlled value empty means nothing is pre-highlighted, so the
+      // first arrow press lands on — and announces — the first option instead of
+      // skipping it.
+      if (!hasNavigatedRef.current) return;
+      setActiveValue(nextActive);
+      if (!nextActive) return;
+      const option = displayOptions.find(
+        opt => getOptionValueFn(opt).toLowerCase() === nextActive.toLowerCase(),
+      );
+      if (option) setAnnouncement(`${getOptionLabel?.(option) ?? nextActive}, selected`);
+    },
+    [displayOptions, getOptionValueFn, getOptionLabel],
   );
 
-  // Keep a valid option highlighted while the list is open so there is always
-  // something to announce (and so the single-result case has an active option).
-  // When the results change under a stale highlight, snap to the first option.
-  // Reset when the list closes.
+  // Reset navigation tracking when the list closes.
   useEffect(() => {
     if (!open) {
       setActiveValue('');
-      return;
+      hasNavigatedRef.current = false;
     }
-    if (displayOptions.length > 0 && !activeOption) {
-      setActiveValue(getOptionValueFn(displayOptions[0]));
-    }
-  }, [open, displayOptions, activeOption, getOptionValueFn]);
+  }, [open]);
 
-  // Announce the active option, with its position, as the highlight moves —
-  // following the combobox pattern ("<label>, <n> of <total>"). cmdk keeps the
-  // combobox `aria-activedescendant` in sync, but VoiceOver does not reliably
-  // speak activedescendant changes on comboboxes, so we mirror the active option
-  // into the live region. The position also conveys the result count and how it
-  // changes as the list narrows. States with no highlightable option (loading, a
-  // failed fetch, an empty result set) are announced in their place. A selection
-  // announcement (set in handleSelect) is left untouched because this effect
-  // exits once the list closes.
+  // Announce the state of the suggestion list when it opens or the results
+  // change: the number of suggestions plus how to browse them, or the loading /
+  // error / empty-result message. Individual options are announced separately as
+  // the user navigates (handleActiveChange). This effect does not re-run on
+  // navigation (its deps do not include the active option) and exits once the
+  // list closes, so it never clobbers an option or selection announcement.
   useEffect(() => {
     if (!open) return;
     if (loading) setAnnouncement(loadingMessage);
     else if (error) setAnnouncement(errorMessage);
-    else if (hasSearched && displayOptions.length === 0) setAnnouncement(emptyMessage);
-    else if (activeOption) {
-      const label = getOptionLabel?.(activeOption) ?? activeValue;
-      const position = displayOptions.indexOf(activeOption) + 1;
-      setAnnouncement(`${label}, ${position} of ${displayOptions.length}`);
+    else if (displayOptions.length > 0) {
+      const count = displayOptions.length;
+      const suggestions = count === 1 ? '1 suggestion' : `${count} suggestions`;
+      setAnnouncement(
+        `There ${count === 1 ? 'is' : 'are'} ${suggestions}, use the up and down arrow keys to browse.`,
+      );
+    } else if (hasSearched) {
+      setAnnouncement(emptyMessage);
     }
   }, [
     open,
     loading,
     error,
     hasSearched,
-    displayOptions,
-    activeOption,
-    activeValue,
+    displayOptions.length,
     loadingMessage,
     errorMessage,
     emptyMessage,
-    getOptionLabel,
   ]);
 
   return (
@@ -290,10 +304,24 @@ function AutocompleteInner<T>(
             className={cn('min-w-[--radix-popover-trigger-width] px-0 py-0', popoverClassName)}
             zIndex={resolvedZIndex}
           >
-            <Command shouldFilter={false} value={activeValue} onValueChange={setActiveValue}>
+            <Command shouldFilter={false} value={activeValue} onValueChange={handleActiveChange}>
               <CommandInput
                 placeholder={placeholder}
                 value={inputValue}
+                onKeyDown={e => {
+                  // Mark real navigation so the next active-option change is
+                  // announced (vs. cmdk's automatic highlight on open).
+                  if (
+                    e.key === 'ArrowDown' ||
+                    e.key === 'ArrowUp' ||
+                    e.key === 'Home' ||
+                    e.key === 'End' ||
+                    e.key === 'PageUp' ||
+                    e.key === 'PageDown'
+                  ) {
+                    hasNavigatedRef.current = true;
+                  }
+                }}
                 onValueChange={handleInputChange}
               />
               {loading ? <CommandLoading>{loadingMessage}</CommandLoading> : null}

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -9,10 +9,12 @@ import {
   CommandLoading,
 } from '@/components/Command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/Popover';
+import { useComposedTriggerLabel } from '@/hooks';
 import { cn } from '@/lib/utils';
 import { getZIndex } from '@/lib/z-index';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Check, ChevronsUpDown, X } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { AutocompleteProps } from '../types';
 
 function AutocompleteInner<T>(
@@ -195,11 +197,21 @@ function AutocompleteInner<T>(
   }, [onChange]);
 
   const showClear = !isDisabled && Boolean(value || inputValue);
+  const hasSelection = Boolean(displayItem || value);
 
-  // Label spoken when the trigger is focused. Appends ", selected" so a screen
-  // reader conveys that the text is the current selection, not just the value.
-  const selectedLabel = displayItem ? (getOptionLabel?.(displayItem) ?? value) : value;
-  const triggerAriaLabel = selectedLabel ? `${selectedLabel}, selected` : undefined;
+  // Compose the trigger's accessible name from its associated label (e.g. from
+  // FormItem) plus the displayed value, so a screen reader reads back the field
+  // label AND the current selection instead of one overriding the other. A
+  // native `<label for>` otherwise becomes the whole name of a <button> and
+  // drops the value. See useComposedTriggerLabel for the full rationale. The
+  // value span also carries a visually-hidden "selected" (below), so the
+  // composed name reads "<label> <value> selected".
+  const valueId = useId();
+  const triggerLabelledBy = useComposedTriggerLabel(triggerRef, valueId, {
+    'aria-label': props['aria-label'],
+    'aria-labelledby': props['aria-labelledby'],
+  });
+  const composedRef = useComposedRefs(ref, triggerRef);
 
   // Announce the highlighted option as the user arrows through the list. cmdk
   // keeps the combobox `aria-activedescendant` in sync, but VoiceOver does not
@@ -276,13 +288,8 @@ function AutocompleteInner<T>(
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <Button
-              ref={el => {
-                if (typeof ref === 'function') ref(el);
-                else if (ref) ref.current = el;
-                triggerRef.current = el;
-              }}
+              ref={composedRef}
               aria-expanded={open}
-              aria-label={triggerAriaLabel}
               autoFocus={autoFocus}
               className={cn(
                 'w-full justify-start px-3 text-left font-normal',
@@ -293,6 +300,7 @@ function AutocompleteInner<T>(
               isDisabled={isDisabled}
               variant="input"
               {...props}
+              aria-labelledby={triggerLabelledBy}
               onKeyDown={e => {
                 if ((e.key === 'Delete' || e.key === 'Backspace') && value && !open) {
                   e.preventDefault();
@@ -301,12 +309,16 @@ function AutocompleteInner<T>(
                 props.onKeyDown?.(e);
               }}
             >
-              <span className="truncate">
+              <span className="truncate" id={valueId}>
                 {displayItem
                   ? renderValue
                     ? renderValue(displayItem)
                     : (getOptionLabel?.(displayItem) ?? value)
                   : value || placeholder}
+                {/* Conveys, to a screen reader, that the text is the current
+                    selection. Part of the value span so it is included whether
+                    the name comes from aria-labelledby or the trigger content. */}
+                {hasSelection ? <span className="sr-only"> selected</span> : null}
               </span>
             </Button>
           </PopoverTrigger>

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -52,6 +52,7 @@ function AutocompleteInner<T>(
   const [asyncOptions, setAsyncOptions] = useState<T[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedItem, setSelectedItem] = useState<T | undefined>(undefined);
+  const [selectionMessage, setSelectionMessage] = useState('');
 
   // Debounce timer reference
   const debounceTimer = useRef<NodeJS.Timeout>();
@@ -124,13 +125,17 @@ function AutocompleteInner<T>(
       const option = displayOptions.find(opt => getOptionValueFn(opt) === selectedValue);
       if (option) {
         setSelectedItem(option);
+        // Announce the chosen value: the popover closes on select, so the
+        // listbox status region goes silent and returning focus to the trigger
+        // is not a reliable announcement across screen readers.
+        setSelectionMessage(`${getOptionLabel?.(option) ?? selectedValue} selected`);
         onChange(selectedValue, option);
       }
       setOpen(false);
       setInputValue('');
       setHasSearched(false);
     },
-    [onChange, displayOptions, getOptionValueFn],
+    [onChange, displayOptions, getOptionValueFn, getOptionLabel],
   );
 
   const handleInputChange = useCallback(
@@ -162,9 +167,36 @@ function AutocompleteInner<T>(
     setInputValue('');
     setAsyncOptions([]);
     setHasSearched(false);
+    setSelectionMessage('');
   }, [onChange]);
 
   const showClear = !isDisabled && Boolean(value || inputValue);
+
+  // Status announced to screen readers when the list opens or its contents
+  // change. Screen readers otherwise only speak items via aria-activedescendant
+  // while arrowing through the list, so a single result or an empty result set
+  // would pass silently. Gated on `open` so it re-announces each time the list
+  // is shown.
+  const listboxStatus = useMemo(() => {
+    if (!open) return '';
+    if (loading) return loadingMessage;
+    if (error) return errorMessage;
+    if (hasSearched && displayOptions.length === 0) return emptyMessage;
+    if (displayOptions.length > 0) {
+      const count = displayOptions.length;
+      return `${count} ${count === 1 ? 'result' : 'results'} available`;
+    }
+    return '';
+  }, [
+    open,
+    loading,
+    error,
+    hasSearched,
+    displayOptions.length,
+    loadingMessage,
+    errorMessage,
+    emptyMessage,
+  ]);
 
   return (
     <>
@@ -273,6 +305,12 @@ function AutocompleteInner<T>(
           className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 shrink-0 -translate-y-1/2
             opacity-50"
         />
+        <div aria-live="polite" className="sr-only" role="status">
+          {listboxStatus}
+        </div>
+        <div aria-live="polite" className="sr-only" role="status">
+          {selectionMessage}
+        </div>
       </div>
     </>
   );

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -231,9 +231,15 @@ function AutocompleteInner<T>(
       const option = displayOptions.find(
         opt => getOptionValueFn(opt).toLowerCase() === nextActive.toLowerCase(),
       );
-      if (option) setAnnouncement(`${getOptionLabel?.(option) ?? nextActive}, selected`);
+      if (option) {
+        const label = getOptionLabel?.(option) ?? nextActive;
+        // Distinguish the option that is the current committed selection from a
+        // merely highlighted one, so a screen reader user knows which is chosen.
+        const isChosen = Boolean(value) && getOptionValueFn(option) === value;
+        setAnnouncement(`${label}, selected${isChosen ? ', current selection' : ''}`);
+      }
     },
-    [displayOptions, getOptionValueFn, getOptionLabel],
+    [displayOptions, getOptionValueFn, getOptionLabel, value],
   );
 
   // Reset navigation tracking when the list closes.
@@ -290,6 +296,7 @@ function AutocompleteInner<T>(
             <Button
               ref={composedRef}
               aria-expanded={open}
+              aria-haspopup="listbox"
               autoFocus={autoFocus}
               className={cn(
                 'w-full justify-start px-3 text-left font-normal',
@@ -305,6 +312,11 @@ function AutocompleteInner<T>(
                 if ((e.key === 'Delete' || e.key === 'Backspace') && value && !open) {
                   e.preventDefault();
                   handleClear();
+                } else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && !open) {
+                  // Open the list with the arrow keys, as the combobox pattern
+                  // expects (Enter/Space already open it via the trigger).
+                  e.preventDefault();
+                  setOpen(true);
                 }
                 props.onKeyDown?.(e);
               }}
@@ -327,7 +339,15 @@ function AutocompleteInner<T>(
             className={cn('min-w-[--radix-popover-trigger-width] px-0 py-0', popoverClassName)}
             zIndex={resolvedZIndex}
           >
-            <Command shouldFilter={false} value={activeValue} onValueChange={handleActiveChange}>
+            {/* `label` gives the search combobox a programmatic accessible name
+                (cmdk renders a visually-hidden <label> the input points at via
+                aria-labelledby); a placeholder alone is not a label. */}
+            <Command
+              label={placeholder}
+              shouldFilter={false}
+              value={activeValue}
+              onValueChange={handleActiveChange}
+            >
               <CommandInput
                 placeholder={placeholder}
                 value={inputValue}
@@ -376,12 +396,18 @@ function AutocompleteInner<T>(
                           ) : (
                             <>
                               <Check
+                                aria-hidden="true"
                                 className={cn(
                                   'mr-2 h-4 w-4',
                                   isSelected ? 'opacity-100' : 'opacity-0',
                                 )}
                               />
                               {getOptionLabel?.(option) ?? optValue}
+                              {/* The check mark is the visual cue for the current
+                                  selection; expose it to assistive tech too. */}
+                              {isSelected ? (
+                                <span className="sr-only"> (current selection)</span>
+                              ) : null}
                             </>
                           )}
                         </CommandItem>

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -2,7 +2,6 @@ import { Button } from '@/components/Button';
 import {
   Command,
   CommandForceEmpty,
-  CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
@@ -250,40 +249,31 @@ function AutocompleteInner<T>(
     }
   }, [open]);
 
-  // Announce the state of the suggestion list when it opens or the results
-  // change: the number of suggestions, how to browse them, and the first
-  // suggestion (the option cmdk highlights) so its content is read even when the
-  // user has not arrowed yet — e.g. after filtering to a single result. Or the
-  // loading / error / empty-result message. Options are also announced as the
-  // user navigates (handleActiveChange). This effect does not re-run on
-  // navigation (its deps do not include the active option) and exits once the
-  // list closes, so it never clobbers an option or selection announcement.
-  useEffect(() => {
-    if (!open) return;
-    if (loading) setAnnouncement(loadingMessage);
-    else if (error) setAnnouncement(errorMessage);
+  // The status of the suggestion list when it opens or the results change: the
+  // number of suggestions, how to browse them, and the first suggestion (so its
+  // content is read even before the user arrows — e.g. a single result); or the
+  // loading / error / empty-result message. Built as a plain string so the
+  // effect below can depend on its VALUE. A navigation re-render produces the
+  // same status string (the result set is unchanged), so it is not re-announced
+  // on top of each option announcement — unlike depending on `displayOptions`
+  // or the option accessors, whose identities change every render.
+  let listStatus = '';
+  if (open) {
+    if (loading) listStatus = loadingMessage;
+    else if (error) listStatus = errorMessage;
     else if (displayOptions.length > 0) {
       const count = displayOptions.length;
       const suggestions = count === 1 ? '1 suggestion' : `${count} suggestions`;
       const firstLabel = getOptionLabel?.(displayOptions[0]) ?? getOptionValueFn(displayOptions[0]);
-      setAnnouncement(
-        `There ${count === 1 ? 'is' : 'are'} ${suggestions}, use the up and down arrow keys to browse. ${firstLabel}, 1 of ${count}.`,
-      );
+      listStatus = `There ${count === 1 ? 'is' : 'are'} ${suggestions}, use the up and down arrow keys to browse. ${firstLabel}, 1 of ${count}.`;
     } else if (hasSearched) {
-      setAnnouncement(emptyMessage);
+      listStatus = emptyMessage;
     }
-  }, [
-    open,
-    loading,
-    error,
-    hasSearched,
-    displayOptions,
-    loadingMessage,
-    errorMessage,
-    emptyMessage,
-    getOptionLabel,
-    getOptionValueFn,
-  ]);
+  }
+
+  useEffect(() => {
+    if (listStatus) setAnnouncement(listStatus);
+  }, [listStatus]);
 
   return (
     <>
@@ -372,48 +362,48 @@ function AutocompleteInner<T>(
               {!loading && !error && hasSearched && displayOptions.length === 0 ? (
                 <CommandForceEmpty>{emptyMessage}</CommandForceEmpty>
               ) : null}
+              {/* No CommandGroup wrapper: it adds a role="group" around the
+                  options, and some screen readers (VoiceOver) announce that lone
+                  group's position ("1 of 1") on every option. Rendering the
+                  options directly in the listbox keeps each option's own
+                  aria-posinset/aria-setsize the position that is read. */}
               {!loading && !error && displayOptions.length > 0 ? (
                 <CommandList className={cn('max-h-[16.5rem] overflow-y-auto', listClassName)}>
-                  <CommandGroup>
-                    {displayOptions.map((option, index) => {
-                      const optValue = getOptionValueFn(option);
-                      const isSelected = Boolean(optValue && value && optValue === value);
+                  {displayOptions.map((option, index) => {
+                    const optValue = getOptionValueFn(option);
+                    const isSelected = Boolean(optValue && value && optValue === value);
 
-                      return (
-                        <CommandItem
-                          key={optValue || index}
-                          // Options sit inside a nested role="group", so screen
-                          // readers cannot infer each one's position in the list
-                          // and announce "1 of 1". Set it explicitly.
-                          aria-posinset={index + 1}
-                          aria-setsize={displayOptions.length}
-                          className="cursor-pointer"
-                          value={optValue}
-                          onSelect={handleSelect}
-                        >
-                          {renderOption ? (
-                            renderOption(option, isSelected)
-                          ) : (
-                            <>
-                              <Check
-                                aria-hidden="true"
-                                className={cn(
-                                  'mr-2 h-4 w-4',
-                                  isSelected ? 'opacity-100' : 'opacity-0',
-                                )}
-                              />
-                              {getOptionLabel?.(option) ?? optValue}
-                              {/* The check mark is the visual cue for the current
-                                  selection; expose it to assistive tech too. */}
-                              {isSelected ? (
-                                <span className="sr-only"> (current selection)</span>
-                              ) : null}
-                            </>
-                          )}
-                        </CommandItem>
-                      );
-                    })}
-                  </CommandGroup>
+                    return (
+                      <CommandItem
+                        key={optValue || index}
+                        aria-posinset={index + 1}
+                        aria-setsize={displayOptions.length}
+                        className="cursor-pointer"
+                        value={optValue}
+                        onSelect={handleSelect}
+                      >
+                        {renderOption ? (
+                          renderOption(option, isSelected)
+                        ) : (
+                          <>
+                            <Check
+                              aria-hidden="true"
+                              className={cn(
+                                'mr-2 h-4 w-4',
+                                isSelected ? 'opacity-100' : 'opacity-0',
+                              )}
+                            />
+                            {getOptionLabel?.(option) ?? optValue}
+                            {/* The check mark is the visual cue for the current
+                                selection; expose it to assistive tech too. */}
+                            {isSelected ? (
+                              <span className="sr-only"> (current selection)</span>
+                            ) : null}
+                          </>
+                        )}
+                      </CommandItem>
+                    );
+                  })}
                 </CommandList>
               ) : null}
             </Command>

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -15,6 +15,11 @@ import { Check, ChevronsUpDown, X } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AutocompleteProps } from '../types';
 
+// Delay before the result-set status is announced to screen readers. Debounced
+// so a burst of typing queues only the final message (like a typeahead backend
+// query) instead of one announcement per keystroke.
+const ANNOUNCE_DEBOUNCE_MS = 500;
+
 function AutocompleteInner<T>(
   {
     loadOptions,
@@ -52,7 +57,8 @@ function AutocompleteInner<T>(
   const [asyncOptions, setAsyncOptions] = useState<T[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedItem, setSelectedItem] = useState<T | undefined>(undefined);
-  const [selectionMessage, setSelectionMessage] = useState('');
+  // Single message read out to screen readers via a polite live region.
+  const [announcement, setAnnouncement] = useState('');
 
   // Debounce timer reference
   const debounceTimer = useRef<NodeJS.Timeout>();
@@ -125,10 +131,11 @@ function AutocompleteInner<T>(
       const option = displayOptions.find(opt => getOptionValueFn(opt) === selectedValue);
       if (option) {
         setSelectedItem(option);
-        // Announce the chosen value: the popover closes on select, so the
-        // listbox status region goes silent and returning focus to the trigger
-        // is not a reliable announcement across screen readers.
-        setSelectionMessage(`${getOptionLabel?.(option) ?? selectedValue} selected`);
+        // Announce the chosen value immediately (not debounced): the popover
+        // closes on select, so the result-set status goes silent and returning
+        // focus to the trigger is not a reliable announcement across screen
+        // readers.
+        setAnnouncement(`${getOptionLabel?.(option) ?? selectedValue} selected`);
         onChange(selectedValue, option);
       }
       setOpen(false);
@@ -167,26 +174,37 @@ function AutocompleteInner<T>(
     setInputValue('');
     setAsyncOptions([]);
     setHasSearched(false);
-    setSelectionMessage('');
+    setAnnouncement('');
   }, [onChange]);
 
   const showClear = !isDisabled && Boolean(value || inputValue);
 
-  // Status announced to screen readers when the list opens or its contents
-  // change. Screen readers otherwise only speak items via aria-activedescendant
-  // while arrowing through the list, so a single result or an empty result set
-  // would pass silently. Gated on `open` so it re-announces each time the list
-  // is shown.
-  const listboxStatus = useMemo(() => {
-    if (!open) return '';
-    if (loading) return loadingMessage;
-    if (error) return errorMessage;
-    if (hasSearched && displayOptions.length === 0) return emptyMessage;
-    if (displayOptions.length > 0) {
-      const count = displayOptions.length;
-      return `${count} ${count === 1 ? 'result' : 'results'} available`;
-    }
-    return '';
+  // Announce the result-set status to screen readers when the list is open.
+  // Screen readers otherwise only speak items via aria-activedescendant while
+  // arrowing through the list, so a single result or an empty result set would
+  // pass silently. Debounced so a burst of typing queues only the final message
+  // rather than one announcement per keystroke. A selection announcement (set
+  // synchronously in handleSelect) is not clobbered here because this effect
+  // exits early once the list has closed.
+  useEffect(() => {
+    if (!open) return;
+
+    const timer = setTimeout(() => {
+      if (loading) {
+        setAnnouncement(loadingMessage);
+      } else if (error) {
+        setAnnouncement(errorMessage);
+      } else if (hasSearched && displayOptions.length === 0) {
+        setAnnouncement(emptyMessage);
+      } else if (displayOptions.length > 0) {
+        const count = displayOptions.length;
+        setAnnouncement(`${count} ${count === 1 ? 'result' : 'results'} available`);
+      } else {
+        setAnnouncement('');
+      }
+    }, ANNOUNCE_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
   }, [
     open,
     loading,
@@ -306,10 +324,7 @@ function AutocompleteInner<T>(
             opacity-50"
         />
         <div aria-live="polite" className="sr-only" role="status">
-          {listboxStatus}
-        </div>
-        <div aria-live="polite" className="sr-only" role="status">
-          {selectionMessage}
+          {announcement}
         </div>
       </div>
     </>

--- a/src/components/Autocomplete/src/Autocomplete.tsx
+++ b/src/components/Autocomplete/src/Autocomplete.tsx
@@ -63,6 +63,10 @@ function AutocompleteInner<T>(
   // Debounce timer reference
   const debounceTimer = useRef<NodeJS.Timeout>();
 
+  // The trigger button, so focus can be returned to it when the (unmounting)
+  // clear button is used.
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
   // Cleanup timer on unmount
   useEffect(() => {
     return () => {
@@ -175,6 +179,10 @@ function AutocompleteInner<T>(
     setAsyncOptions([]);
     setHasSearched(false);
     setAnnouncement('');
+    // Clearing removes the clear button from the DOM, so focus would otherwise
+    // fall to <body>. Return it to the trigger. Deferred until after the
+    // re-render that unmounts the clear button.
+    requestAnimationFrame(() => triggerRef.current?.focus());
   }, [onChange]);
 
   const showClear = !isDisabled && Boolean(value || inputValue);
@@ -225,7 +233,11 @@ function AutocompleteInner<T>(
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <Button
-              ref={ref}
+              ref={el => {
+                if (typeof ref === 'function') ref(el);
+                else if (ref) ref.current = el;
+                triggerRef.current = el;
+              }}
               aria-expanded={open}
               autoFocus={autoFocus}
               className={cn(

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -300,11 +300,12 @@ export const MinWidthPopover: Story = {
  * timeline. The "Current live-region text" panel mirrors the region visibly
  * (the panels are `aria-hidden` so they are not themselves announced).
  *
- * To debug: open the list (the highlighted option and its position are
- * announced, e.g. "React, 1 of 3"), arrow through the options (each active
- * option and position is announced), narrow to one result ("Angular, 1 of 1"),
- * search for nothing ("No results found"), and select an option ("<label>
- * selected", then focus returns to the trigger).
+ * To debug: open the list (the suggestion count and instructions are announced,
+ * e.g. "There are 3 suggestions, use the up and down arrow keys to browse."),
+ * arrow through the options (each highlighted option is announced, e.g. "Vue,
+ * selected"), narrow to one result ("There is 1 suggestion, ..."), search for
+ * nothing ("No results found"), and select an option ("<label> selected", then
+ * focus returns to the trigger).
  */
 export const AnnouncementDebug: Story = {
   render: () => <AutocompleteAnnouncementDebug />,

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -300,12 +300,12 @@ export const MinWidthPopover: Story = {
  * timeline. The "Current live-region text" panel mirrors the region visibly
  * (the panels are `aria-hidden` so they are not themselves announced).
  *
- * To debug: open the list (the suggestion count and instructions are announced,
- * e.g. "There are 3 suggestions, use the up and down arrow keys to browse."),
- * arrow through the options (each highlighted option is announced, e.g. "Vue,
- * selected"), narrow to one result ("There is 1 suggestion, ..."), search for
- * nothing ("No results found"), and select an option ("<label> selected", then
- * focus returns to the trigger).
+ * To debug: open the list (the count, instructions, and first suggestion are
+ * announced, e.g. "There are 3 suggestions, use the up and down arrow keys to
+ * browse. React, 1 of 3."), arrow through the options (each highlighted option
+ * is announced, e.g. "Vue, selected"), narrow to one result ("There is 1
+ * suggestion, ... Angular, 1 of 1."), search for nothing ("No results found"),
+ * and select an option ("<label> selected", then focus returns to the trigger).
  */
 export const AnnouncementDebug: Story = {
   render: () => <AutocompleteAnnouncementDebug />,

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -300,11 +300,11 @@ export const MinWidthPopover: Story = {
  * timeline. The "Current live-region text" panel mirrors the region visibly
  * (the panels are `aria-hidden` so they are not themselves announced).
  *
- * To debug: open the list (the highlighted option's label is announced),
- * arrow through the options (each active option is announced), narrow to one
- * result (the sole option is announced), search for nothing ("No results
- * found"), and select an option ("<label> selected", then focus returns to the
- * trigger).
+ * To debug: open the list (the highlighted option and its position are
+ * announced, e.g. "React, 1 of 3"), arrow through the options (each active
+ * option and position is announced), narrow to one result ("Angular, 1 of 1"),
+ * search for nothing ("No results found"), and select an option ("<label>
+ * selected", then focus returns to the trigger).
  */
 export const AnnouncementDebug: Story = {
   render: () => <AutocompleteAnnouncementDebug />,

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -300,9 +300,10 @@ export const MinWidthPopover: Story = {
  * timeline. The "Current live-region text" panel mirrors the region visibly
  * (the panels are `aria-hidden` so they are not themselves announced).
  *
- * To debug: open the list (see "N results available"), narrow to one result
- * ("1 result available"), search for nothing ("No results found"), and select
- * an option (should log "<label> selected", then focus returning to the
+ * To debug: open the list (the highlighted option's label is announced),
+ * arrow through the options (each active option is announced), narrow to one
+ * result (the sole option is announced), search for nothing ("No results
+ * found"), and select an option ("<label> selected", then focus returns to the
  * trigger).
  */
 export const AnnouncementDebug: Story = {

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -12,6 +12,8 @@ import { AutocompleteMinWidthPopover } from '../demos/AutocompleteMinWidthPopove
 import sourceCodeMinWidthPopover from '../demos/AutocompleteMinWidthPopover.tsx?raw';
 import { AutocompleteWithStaticOptions } from '../demos/AutocompleteWithStaticOptions';
 import sourceCodeWithStaticOptions from '../demos/AutocompleteWithStaticOptions.tsx?raw';
+import { AutocompleteAnnouncementDebug } from '../demos/AutocompleteAnnouncementDebug';
+import sourceCodeAnnouncementDebug from '../demos/AutocompleteAnnouncementDebug.tsx?raw';
 import { Autocomplete } from '../src/Autocomplete';
 
 const meta = {
@@ -272,6 +274,34 @@ export const WithItemCallback: Story = {
  * uses `popoverClassName` so it can be wider than the trigger - the dropdown expands to
  * fit long option labels.
  */
+/**
+ * Debug harness for the screen-reader announcements (508). It watches the real
+ * `[role="status"][aria-live]` live region with a MutationObserver and logs
+ * every text change — this is exactly what a screen reader would speak — plus
+ * focus moves, so announcements and focus changes can be correlated on a
+ * timeline. The "Current live-region text" panel mirrors the region visibly
+ * (the panels are `aria-hidden` so they are not themselves announced).
+ *
+ * To debug: open the list (see "N results available"), narrow to one result
+ * ("1 result available"), search for nothing ("No results found"), and select
+ * an option (should log "<label> selected", then focus returning to the
+ * trigger).
+ */
+export const AnnouncementDebug: Story = {
+  render: () => <AutocompleteAnnouncementDebug />,
+  // @ts-expect-error - Storybook can't properly infer generic types
+  args: {},
+  tags: ['!autodocs'],
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeAnnouncementDebug,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
 export const MinWidthPopover: Story = {
   render: () => <AutocompleteMinWidthPopover value="" onChange={() => {}} />,
   // @ts-expect-error - Storybook can't properly infer generic types

--- a/src/components/Autocomplete/stories/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/stories/Autocomplete.stories.tsx
@@ -274,6 +274,24 @@ export const WithItemCallback: Story = {
  * uses `popoverClassName` so it can be wider than the trigger - the dropdown expands to
  * fit long option labels.
  */
+export const MinWidthPopover: Story = {
+  render: () => <AutocompleteMinWidthPopover value="" onChange={() => {}} />,
+  // @ts-expect-error - Storybook can't properly infer generic types
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Uses a fixed-width trigger, which demonstrates ellipsis when the label content is too long. The popover content uses popoverClassName to set a minimum width, so it can grow when options are wider. Open the dropdown to see it expand for long labels.',
+      },
+      source: {
+        code: sourceCodeMinWidthPopover,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
 /**
  * Debug harness for the screen-reader announcements (508). It watches the real
  * `[role="status"][aria-live]` live region with a MutationObserver and logs
@@ -296,24 +314,6 @@ export const AnnouncementDebug: Story = {
     docs: {
       source: {
         code: sourceCodeAnnouncementDebug,
-        language: 'tsx',
-      },
-    },
-  },
-};
-
-export const MinWidthPopover: Story = {
-  render: () => <AutocompleteMinWidthPopover value="" onChange={() => {}} />,
-  // @ts-expect-error - Storybook can't properly infer generic types
-  args: {},
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Uses a fixed-width trigger, which demonstrates ellipsis when the label content is too long. The popover content uses popoverClassName to set a minimum width, so it can grow when options are wider. Open the dropdown to see it expand for long labels.',
-      },
-      source: {
-        code: sourceCodeMinWidthPopover,
         language: 'tsx',
       },
     },

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useAriaDisabled';
 export * from './useAriaLabelled';
+export * from './useComposedTriggerLabel';
 export * from './useFormGroupLayout';

--- a/src/hooks/useComposedTriggerLabel.ts
+++ b/src/hooks/useComposedTriggerLabel.ts
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+export type UseComposedTriggerLabelOptions = {
+  /** A consumer-supplied aria-label, if any. When present it provides the whole name. */
+  'aria-label'?: string;
+  /** A consumer-supplied aria-labelledby, if any. The value id is appended to it. */
+  'aria-labelledby'?: string;
+};
+
+/**
+ * Composes an `aria-labelledby` for a button-style trigger whose accessible name must
+ * combine an associated external `<label>` with the trigger's displayed value.
+ *
+ * A native `<label for>` (e.g. the one FormItem renders) becomes a `<button>`'s accessible
+ * name and *overrides* its text content, so the value shown in the trigger ("John Doe")
+ * gets dropped from the accessibility tree and is never read back. Given a ref to the
+ * trigger and the id of the element that holds the value, this returns an `aria-labelledby`
+ * listing the associated label id(s) followed by the value id, so screen readers announce
+ * "Label, Value".
+ *
+ * Returns `undefined` when the trigger has no associated label and no consumer-supplied
+ * `aria-labelledby` — letting the accessible name fall back to the trigger's content
+ * (which is the value), so an unlabeled trigger still reads correctly.
+ *
+ * Known gap — a bare `aria-label`: when the consumer supplies an `aria-label` (a plain
+ * string, with no associated `<label>` or `aria-labelledby`), it becomes the entire
+ * accessible name and the value is NOT appended, so the selection is not read back. This
+ * is a deliberate decision: we respect the consumer's explicit `aria-label` rather than
+ * override it, and it is not a regression (a bare `aria-label` already overrode the
+ * trigger's content before this hook existed). It could be closed by rendering a
+ * visually-hidden element holding the label text and composing it with the value id, at
+ * the cost of an extra DOM node; we opted not to since a bare `aria-label` on a
+ * select-style trigger is uncommon. Prefer a visible label (via FormItem, a `<label for>`,
+ * or `aria-labelledby`) to get the value read back.
+ *
+ * @param triggerRef - Ref to the trigger element. Works with labelable elements (`<button>`,
+ *   via `.labels`) and non-labelable triggers like `<div role="button">` (matched by id
+ *   against `<label for>`); the latter must carry an `id` for its label to be found.
+ * @param valueId - Id of the element rendering the current value.
+ * @param options - Consumer-supplied aria-label / aria-labelledby to respect.
+ */
+export function useComposedTriggerLabel(
+  triggerRef: React.RefObject<HTMLElement | null>,
+  valueId: string,
+  {
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+  }: UseComposedTriggerLabelOptions = {},
+): string | undefined {
+  // Seed with the consumer value so SSR / first paint has a sensible name; the effect
+  // refines it once the DOM (and any associated label) is available.
+  const [labelledBy, setLabelledBy] = useState<string | undefined>(ariaLabelledBy);
+
+  useEffect(() => {
+    // An explicit aria-label provides the entire accessible name; don't compose.
+    if (ariaLabel) {
+      setLabelledBy(undefined);
+      return;
+    }
+
+    // A consumer-supplied aria-labelledby wins for the label portion; append the value.
+    if (ariaLabelledBy) {
+      setLabelledBy(`${ariaLabelledBy} ${valueId}`);
+      return;
+    }
+
+    const el = triggerRef.current;
+    if (!el) {
+      setLabelledBy(undefined);
+      return;
+    }
+
+    // Prefer the native `.labels` collection (labelable elements like <button>). For a
+    // non-labelable trigger such as a `<div role="button">` (MultiSelect), a `<label for>`
+    // never associates, so fall back to finding it by the trigger's id.
+    const nativeLabels = (el as HTMLButtonElement).labels;
+    let labels: HTMLElement[] =
+      nativeLabels && nativeLabels.length > 0 ? Array.from(nativeLabels) : [];
+    if (labels.length === 0 && el.id) {
+      labels = Array.from(el.ownerDocument.querySelectorAll('label')).filter(
+        label => (label as HTMLLabelElement).htmlFor === el.id,
+      );
+    }
+
+    if (labels.length === 0) {
+      // No associated label: fall back to the trigger's content (the value).
+      setLabelledBy(undefined);
+      return;
+    }
+
+    const labelIds = labels.map((label, index) => {
+      // Ensure every associated label can be referenced; only assign when missing so we
+      // never clobber an id a consumer set.
+      if (!label.id) label.id = `${valueId}-label-${index}`;
+      return label.id;
+    });
+
+    setLabelledBy(`${labelIds.join(' ')} ${valueId}`);
+  }, [triggerRef, valueId, ariaLabel, ariaLabelledBy]);
+
+  return labelledBy;
+}


### PR DESCRIPTION
## Problem

The Autocomplete is a `cmdk`-based combobox. Screen readers only spoke option text via `aria-activedescendant` **while arrowing through the list**, which requires 2+ items to navigate. Three states passed silently:

1. **Single result** — nothing to arrow to, so nothing announced.
2. **No results** — the "No results found" text rendered visually but wasn't in a live region.
3. **The selected value** — on select the popover closes and focus returns to the trigger, which isn't a reliable announcement across screen readers.

## Fix

- Added two visually-hidden (`sr-only`) `role="status" aria-live="polite"` regions.
- **Listbox status region** announces `"N results available"` (singular `"1 result available"`), or the loading / error / empty message. Gated on `open` so it re-announces each time the list is shown.
- **Selection region** announces `"<label> selected"` when an option is chosen; reset on clear.

## Tests

Added a "Screen reader announcements" describe block covering:
- result count announced on open
- singular wording for a single result
- empty-result announcement
- selected-value announcement

All 10 Autocomplete tests pass; ESLint and `tsc` clean.

> Note: automated tests confirm the live-region *content* updates correctly. Announcement *timing* (e.g. that the "selected" announcement isn't clobbered by focus returning to the trigger) is best confirmed with a real screen reader (VoiceOver/NVDA).