### PR TITLE
Feature: Allow CheckboxGroup and SwitchGroup to take children

### DIFF
--- a/src/components/CheckboxGroup/demos/CheckboxGroupWithChildren.tsx
+++ b/src/components/CheckboxGroup/demos/CheckboxGroupWithChildren.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { Checkbox } from '../../Checkbox';
+import { CheckboxGroup } from '../src/CheckboxGroup';
+
+export const CheckboxGroupWithChildren = () => {
+  const [value, setValue] = useState<string[]>(['email']);
+
+  const toggle = (id: string) => (isChecked: boolean) =>
+    setValue(prev => (isChecked ? [...prev, id] : prev.filter(v => v !== id)));
+
+  return (
+    <div className="space-y-4">
+      <CheckboxGroup>
+        <div className="flex flex-col gap-2">
+          <Checkbox
+            id="children-email"
+            isChecked={value.includes('email')}
+            label="Email"
+            onCheckedChange={toggle('email')}
+          />
+          <Checkbox
+            id="children-sms"
+            isChecked={value.includes('sms')}
+            label="SMS"
+            onCheckedChange={toggle('sms')}
+          />
+        </div>
+      </CheckboxGroup>
+      <p className="text-sm text-muted-foreground">Selected: {value.join(', ') || 'none'}</p>
+    </div>
+  );
+};

--- a/src/components/CheckboxGroup/demos/CheckboxGroupWithChildrenRef.tsx
+++ b/src/components/CheckboxGroup/demos/CheckboxGroupWithChildrenRef.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/Button';
+import { type ComponentRef, useRef, useState } from 'react';
+import { Checkbox } from '../../Checkbox';
+import { CheckboxGroup } from '../src/CheckboxGroup';
+
+export const CheckboxGroupWithChildrenRef = () => {
+  const [value, setValue] = useState<string[]>(['email']);
+  const firstCheckboxRef = useRef<ComponentRef<typeof Checkbox>>(null);
+
+  const toggle = (id: string) => (isChecked: boolean) =>
+    setValue(prev => (isChecked ? [...prev, id] : prev.filter(v => v !== id)));
+
+  const focusFirstCheckbox = () => {
+    firstCheckboxRef.current?.focus();
+  };
+
+  return (
+    <div className="space-y-4">
+      <CheckboxGroup>
+        <div className="flex flex-col gap-2">
+          <Checkbox
+            ref={firstCheckboxRef}
+            id="ref-email"
+            isChecked={value.includes('email')}
+            label="Email"
+            onCheckedChange={toggle('email')}
+          />
+          <Checkbox
+            id="ref-sms"
+            isChecked={value.includes('sms')}
+            label="SMS"
+            onCheckedChange={toggle('sms')}
+          />
+        </div>
+      </CheckboxGroup>
+      <Button size="sm" type="button" variant="primary" onClick={focusFirstCheckbox}>
+        Focus first checkbox
+      </Button>
+      <p className="text-sm text-muted-foreground">Selected: {value.join(', ') || 'none'}</p>
+    </div>
+  );
+};

--- a/src/components/CheckboxGroup/src/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/src/CheckboxGroup.tsx
@@ -9,7 +9,8 @@ const CheckboxGroup = React.forwardRef<HTMLDivElement, CheckboxGroupProps>(
   (
     {
       options,
-      value,
+      children,
+      value = [],
       onChange,
       className,
       columns = 1,
@@ -32,27 +33,29 @@ const CheckboxGroup = React.forwardRef<HTMLDivElement, CheckboxGroupProps>(
         id={groupId}
         {...props}
       >
-        {options.map(option => {
-          const inputId = option.inputId ?? `${computedId}-${option.id}`;
-          return (
-            <Checkbox
-              key={option.id}
-              description={option.description}
-              id={inputId}
-              isChecked={value.includes(option.id)}
-              isDisabled={isDisabled || option.isDisabled}
-              label={option.label}
-              variant={variant}
-              onCheckedChange={isChecked => {
-                if (isChecked) {
-                  onChange([...value, option.id]);
-                } else {
-                  onChange(value.filter(id => id !== option.id));
-                }
-              }}
-            />
-          );
-        })}
+        {options
+          ? options.map(option => {
+              const inputId = option.inputId ?? `${computedId}-${option.id}`;
+              return (
+                <Checkbox
+                  key={option.id}
+                  description={option.description}
+                  id={inputId}
+                  isChecked={value.includes(option.id)}
+                  isDisabled={isDisabled || option.isDisabled}
+                  label={option.label}
+                  variant={variant}
+                  onCheckedChange={isChecked => {
+                    if (isChecked) {
+                      onChange?.([...value, option.id]);
+                    } else {
+                      onChange?.(value.filter(id => id !== option.id));
+                    }
+                  }}
+                />
+              );
+            })
+          : children}
       </div>
     );
   },

--- a/src/components/CheckboxGroup/stories/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/stories/CheckboxGroup.stories.tsx
@@ -21,6 +21,10 @@ import { CheckboxGroupTileWithSelection } from '../demos/CheckboxGroupTileWithSe
 import sourceCodeTileWithSelection from '../demos/CheckboxGroupTileWithSelection.tsx?raw';
 import { CheckboxGroupVertical } from '../demos/CheckboxGroupVertical';
 import sourceCodeVertical from '../demos/CheckboxGroupVertical.tsx?raw';
+import { CheckboxGroupWithChildren } from '../demos/CheckboxGroupWithChildren';
+import sourceCodeWithChildren from '../demos/CheckboxGroupWithChildren.tsx?raw';
+import { CheckboxGroupWithChildrenRef } from '../demos/CheckboxGroupWithChildrenRef';
+import sourceCodeWithChildrenRef from '../demos/CheckboxGroupWithChildrenRef.tsx?raw';
 import { CheckboxGroupWithDescription } from '../demos/CheckboxGroupWithDescription';
 import sourceCodeWithDescription from '../demos/CheckboxGroupWithDescription.tsx?raw';
 import { CheckboxGroupWithSelection } from '../demos/CheckboxGroupWithSelection';
@@ -34,7 +38,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'CheckboxGroup lets users select zero, one, or many options from a list. Use it for multi-select choices (e.g. interests, notification preferences). Options support labels and optional descriptions; layout can be default, tile, or button style, with configurable columns and orientation.\n\nWhen multiple CheckboxGroups appear on the same page with overlapping option IDs, give each group a unique `id` so input IDs stay unique (each checkbox input ID becomes `{id}-{option.id}`). You can override the input ID for a single option by passing an optional `inputId` on that option.',
+          'CheckboxGroup lets users select zero, one, or many options from a list. Use it for multi-select choices (e.g. interests, notification preferences).\n\n**Two usage patterns:**\n- **Options:** Pass an `options` array; CheckboxGroup renders Checkbox items and applies layout (default, tile, or button variant, columns, orientation).\n- **Children:** Pass **Checkbox** components as `children` when you need custom layout or structure (or a ref to a specific Checkbox); you manage each Checkbox’s checked state.\n\nWhen multiple CheckboxGroups appear on the same page with overlapping option IDs, give each group a unique `id` so input IDs stay unique (each checkbox input ID becomes `{id}-{option.id}`). You can override the input ID for a single option by passing an optional `inputId` on that option.',
       },
     },
   },
@@ -449,6 +453,47 @@ export const WithDescription: Story = {
     docs: {
       source: {
         code: sourceCodeWithDescription,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+/**
+ * Instead of an `options` array, pass **Checkbox** components as `children` when
+ * you need custom layout or structure. In this mode you manage each Checkbox's
+ * `isChecked`/`onCheckedChange` yourself; CheckboxGroup just provides the group
+ * wrapper and layout.
+ */
+export const WithChildren: Story = {
+  render: () => <CheckboxGroupWithChildren />,
+  args: {
+    // The children variant takes no value/onChange (the caller manages state).
+    children: undefined,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeWithChildren,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+/**
+ * Passing Checkbox components as `children` lets you hold a ref to an individual
+ * Checkbox — e.g. to move focus to it programmatically.
+ */
+export const WithChildrenAndRef: Story = {
+  render: () => <CheckboxGroupWithChildrenRef />,
+  args: {
+    children: undefined,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeWithChildrenRef,
         language: 'tsx',
       },
     },

--- a/src/components/CheckboxGroup/types.ts
+++ b/src/components/CheckboxGroup/types.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, ReactNode } from 'react';
 
 export interface CheckboxOption {
   /** Option identifier (used in value array). Consider standardizing with RadioGroup, which uses "value" for the option key. */
@@ -10,14 +10,33 @@ export interface CheckboxOption {
   inputId?: string;
 }
 
-export interface CheckboxGroupProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
-  options: CheckboxOption[];
-  value: string[];
-  onChange: (value: string[]) => void;
+type CheckboxGroupBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & {
   className?: string;
   isDisabled?: boolean;
   /** Number of columns for default and tile variants (vertical orientation). Defaults to 1. */
   columns?: 1 | 2 | 3 | 4;
   orientation?: 'horizontal' | 'vertical';
   variant?: 'default' | 'tile' | 'button';
+};
+
+/** Use with an `options` array; CheckboxGroup renders Checkbox items and applies layout. */
+export interface CheckboxGroupPropsWithOptions extends CheckboxGroupBaseProps {
+  options: CheckboxOption[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  children?: never;
 }
+
+/**
+ * Use with Checkbox components as children when you need custom layout or
+ * structure (or a ref to a specific Checkbox). In this mode the caller manages
+ * each Checkbox's checked state, so `value`/`onChange` are not used.
+ */
+export interface CheckboxGroupPropsWithChildren extends CheckboxGroupBaseProps {
+  options?: never;
+  value?: never;
+  onChange?: never;
+  children: ReactNode;
+}
+
+export type CheckboxGroupProps = CheckboxGroupPropsWithOptions | CheckboxGroupPropsWithChildren;

--- a/src/components/SwitchGroup/demos/SwitchGroupWithChildren.tsx
+++ b/src/components/SwitchGroup/demos/SwitchGroupWithChildren.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { Switch } from '../../Switch';
+import { SwitchGroup } from '../src/SwitchGroup';
+
+export const SwitchGroupWithChildren = () => {
+  const [value, setValue] = useState<string[]>(['wifi']);
+
+  const toggle = (id: string) => (isChecked: boolean) =>
+    setValue(prev => (isChecked ? [...prev, id] : prev.filter(v => v !== id)));
+
+  return (
+    <div className="space-y-4">
+      <SwitchGroup>
+        <div className="flex flex-col gap-2">
+          <Switch
+            id="children-wifi"
+            isChecked={value.includes('wifi')}
+            label="Wi-Fi"
+            onCheckedChange={toggle('wifi')}
+          />
+          <Switch
+            id="children-bluetooth"
+            isChecked={value.includes('bluetooth')}
+            label="Bluetooth"
+            onCheckedChange={toggle('bluetooth')}
+          />
+        </div>
+      </SwitchGroup>
+      <p className="text-sm text-muted-foreground">Enabled: {value.join(', ') || 'none'}</p>
+    </div>
+  );
+};

--- a/src/components/SwitchGroup/demos/SwitchGroupWithChildrenRef.tsx
+++ b/src/components/SwitchGroup/demos/SwitchGroupWithChildrenRef.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/Button';
+import { type ComponentRef, useRef, useState } from 'react';
+import { Switch } from '../../Switch';
+import { SwitchGroup } from '../src/SwitchGroup';
+
+export const SwitchGroupWithChildrenRef = () => {
+  const [value, setValue] = useState<string[]>(['wifi']);
+  const firstSwitchRef = useRef<ComponentRef<typeof Switch>>(null);
+
+  const toggle = (id: string) => (isChecked: boolean) =>
+    setValue(prev => (isChecked ? [...prev, id] : prev.filter(v => v !== id)));
+
+  const focusFirstSwitch = () => {
+    firstSwitchRef.current?.focus();
+  };
+
+  return (
+    <div className="space-y-4">
+      <SwitchGroup>
+        <div className="flex flex-col gap-2">
+          <Switch
+            ref={firstSwitchRef}
+            id="ref-wifi"
+            isChecked={value.includes('wifi')}
+            label="Wi-Fi"
+            onCheckedChange={toggle('wifi')}
+          />
+          <Switch
+            id="ref-bluetooth"
+            isChecked={value.includes('bluetooth')}
+            label="Bluetooth"
+            onCheckedChange={toggle('bluetooth')}
+          />
+        </div>
+      </SwitchGroup>
+      <Button size="sm" type="button" variant="primary" onClick={focusFirstSwitch}>
+        Focus first switch
+      </Button>
+      <p className="text-sm text-muted-foreground">Enabled: {value.join(', ') || 'none'}</p>
+    </div>
+  );
+};

--- a/src/components/SwitchGroup/src/SwitchGroup.tsx
+++ b/src/components/SwitchGroup/src/SwitchGroup.tsx
@@ -8,7 +8,8 @@ const SwitchGroup = React.forwardRef<HTMLDivElement, SwitchGroupProps>(
   (
     {
       options,
-      value,
+      children,
+      value = [],
       onChange,
       className,
       columns = 1,
@@ -22,8 +23,8 @@ const SwitchGroup = React.forwardRef<HTMLDivElement, SwitchGroupProps>(
 
     const handleSwitchChange = useCallback(
       (id: string, isChecked: boolean) => {
-        const addId = (id: string) => onChange([...value, id]);
-        const removeId = (id: string) => onChange(value.filter(v => v !== id));
+        const addId = (id: string) => onChange?.([...value, id]);
+        const removeId = (id: string) => onChange?.(value.filter(v => v !== id));
 
         if (isChecked) {
           addId(id);
@@ -36,16 +37,18 @@ const SwitchGroup = React.forwardRef<HTMLDivElement, SwitchGroupProps>(
 
     return (
       <div ref={ref} className={cn('vero-switch-group', layoutClasses, className)} {...props}>
-        {options.map(option => (
-          <Switch
-            key={option.id}
-            id={option.id}
-            isChecked={value.includes(option.id)}
-            isDisabled={isDisabled || option.isDisabled}
-            label={option.label}
-            onCheckedChange={checked => handleSwitchChange(option.id, checked)}
-          />
-        ))}
+        {options
+          ? options.map(option => (
+              <Switch
+                key={option.id}
+                id={option.id}
+                isChecked={value.includes(option.id)}
+                isDisabled={isDisabled || option.isDisabled}
+                label={option.label}
+                onCheckedChange={checked => handleSwitchChange(option.id, checked)}
+              />
+            ))
+          : children}
       </div>
     );
   },

--- a/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
+++ b/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
@@ -7,7 +7,11 @@ import { SwitchGroupWithSelection } from '../demos/SwitchGroupWithSelection';
 import { SwitchGroupSingleColumn } from '../demos/SwitchGroupSingleColumn';
 import { SwitchGroupThreeColumns } from '../demos/SwitchGroupThreeColumns';
 import { SwitchGroupWithManyOptions } from '../demos/SwitchGroupWithManyOptions';
+import { SwitchGroupWithChildren } from '../demos/SwitchGroupWithChildren';
+import { SwitchGroupWithChildrenRef } from '../demos/SwitchGroupWithChildrenRef';
 import sourceCodeDefault from '../demos/SwitchGroupDefault.tsx?raw';
+import sourceCodeWithChildren from '../demos/SwitchGroupWithChildren.tsx?raw';
+import sourceCodeWithChildrenRef from '../demos/SwitchGroupWithChildrenRef.tsx?raw';
 import sourceCodeHorizontal from '../demos/SwitchGroupHorizontal.tsx?raw';
 import sourceCodeVertical from '../demos/SwitchGroupVertical.tsx?raw';
 import sourceCodeWithSelection from '../demos/SwitchGroupWithSelection.tsx?raw';
@@ -232,6 +236,47 @@ export const WithManyOptions: Story = {
     docs: {
       source: {
         code: sourceCodeWithManyOptions,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+/**
+ * Instead of an `options` array, pass **Switch** components as `children` when
+ * you need custom layout or structure. In this mode you manage each Switch's
+ * `isChecked`/`onCheckedChange` yourself; SwitchGroup just provides the group
+ * wrapper and layout.
+ */
+export const WithChildren: Story = {
+  render: () => <SwitchGroupWithChildren />,
+  args: {
+    // The children variant takes no value/onChange (the caller manages state).
+    children: undefined,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeWithChildren,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+/**
+ * Passing Switch components as `children` lets you hold a ref to an individual
+ * Switch — e.g. to move focus to it programmatically.
+ */
+export const WithChildrenAndRef: Story = {
+  render: () => <SwitchGroupWithChildrenRef />,
+  args: {
+    children: undefined,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: sourceCodeWithChildrenRef,
         language: 'tsx',
       },
     },

--- a/src/components/SwitchGroup/types.ts
+++ b/src/components/SwitchGroup/types.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, ReactNode } from 'react';
 
 export interface SwitchOption {
   id: string;
@@ -6,12 +6,31 @@ export interface SwitchOption {
   isDisabled?: boolean;
 }
 
-export interface SwitchGroupProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
-  options: SwitchOption[];
-  value: string[];
+type SwitchGroupBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & {
   className?: string;
   isDisabled?: boolean;
   columns?: 1 | 2 | 3 | 4;
   orientation?: 'horizontal' | 'vertical';
+};
+
+/** Use with an `options` array; SwitchGroup renders Switch items and applies layout. */
+export interface SwitchGroupPropsWithOptions extends SwitchGroupBaseProps {
+  options: SwitchOption[];
+  value: string[];
   onChange: (value: string[]) => void;
+  children?: never;
 }
+
+/**
+ * Use with Switch components as children when you need custom layout or
+ * structure (or a ref to a specific Switch). In this mode the caller manages
+ * each Switch's checked state, so `value`/`onChange` are not used.
+ */
+export interface SwitchGroupPropsWithChildren extends SwitchGroupBaseProps {
+  options?: never;
+  value?: never;
+  onChange?: never;
+  children: ReactNode;
+}
+
+export type SwitchGroupProps = SwitchGroupPropsWithOptions | SwitchGroupPropsWithChildren;


### PR DESCRIPTION
Mirrors the `children` API added to **RadioGroup** ([story](https://capitaltg.github.io/vero/?path=/story/inputs-forms-radiogroup--with-children-and-ref)) for **CheckboxGroup** and **SwitchGroup**, so callers can supply their own Checkbox/Switch children — enabling custom layout/structure and refs to an individual control.

## Changes
- **Types**: `CheckboxGroupProps` / `SwitchGroupProps` are now a discriminated union:
  - **Options mode** (`options`) — unchanged; still requires `value`/`onChange`.
  - **Children mode** (`children`) — `options`/`value`/`onChange` are `never`; the caller manages each control's `isChecked`/`onCheckedChange`.
- **Components**: render `options ? options.map(…) : children` (same shape as RadioGroup).
- **Stories/demos**: `WithChildren` and `WithChildrenAndRef` for each, plus a "Two usage patterns" note in the CheckboxGroup docs.

## Note on the union vs. RadioGroup
RadioGroup keeps `value`/`onChange` in its base (optional in both modes) because it's built on Radix's radio group context. CheckboxGroup/SwitchGroup are plain `<div>`s that only use `value`/`onChange` in options mode, so I scoped them to the options variant (`never` in children mode) rather than loosening the existing options-mode requirement.

## Verified
- Typecheck + lint clean; **full suite 172 tests pass**.
- All four stories register: `checkboxgroup--with-children`, `checkboxgroup--with-children-and-ref`, `switchgroup--with-children`, `switchgroup--with-children-and-ref`.