### PR TITLE
Docs: Note isDisabled is options-mode only for the group controls

### DIFF
--- a/src/components/CheckboxGroup/stories/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/stories/CheckboxGroup.stories.tsx
@@ -100,7 +100,7 @@ const meta = {
     isDisabled: {
       control: 'boolean',
       description:
-        'Disables the entire group. Individual options can also be disabled via `option.isDisabled`.',
+        'Disables the entire group. Individual options can also be disabled via `option.isDisabled`. Applies only in `options` mode; when passing `children`, the group does not disable them — set `isDisabled` on each Checkbox yourself.',
       type: { name: 'boolean', required: false },
       table: {
         type: { summary: 'boolean' },

--- a/src/components/RadioGroup/stories/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/stories/RadioGroup.stories.tsx
@@ -95,6 +95,16 @@ const meta = {
         'Number of columns for default and tile variants (only applies when orientation is vertical). Defaults to 1.',
       type: { name: 'number', required: false },
     },
+    isDisabled: {
+      control: 'boolean',
+      description:
+        'Disables the entire group. Individual options can also be disabled via `option.isDisabled`. Applies only in `options` mode; when passing `children`, the group does not disable them — set `isDisabled` on each Radio yourself.',
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
     required: {
       control: 'boolean',
       description:

--- a/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
+++ b/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
@@ -60,6 +60,16 @@ const meta = {
       description: 'Number of columns in the grid (only applies when orientation is vertical)',
       type: { name: 'number', required: false },
     },
+    isDisabled: {
+      control: 'boolean',
+      description:
+        'Disables the entire group. Individual options can also be disabled via `option.isDisabled`. Applies only in `options` mode; when passing `children`, the group does not disable them — set `isDisabled` on each Switch yourself.',
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof SwitchGroup>;


### PR DESCRIPTION
Adds the children-mode caveat to the `isDisabled` prop docs for **RadioGroup**, **CheckboxGroup**, and **SwitchGroup**:

> Group-level `isDisabled` applies only in `options` mode. When passing `children`, the group does not disable them — set `isDisabled` on each control yourself.

This matches the intentional behavior (the children escape hatch is caller-managed, like `value`/`onChange`).

Also adds the previously-missing `isDisabled` argType entry to RadioGroup and SwitchGroup (CheckboxGroup already had one), so the prop shows up in the Storybook controls/props table for all three.

Docs-only; typecheck + lint clean.