### PR TITLE
feat: add accessible Table and TableRoot components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.7",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "cmdk": "^1.1.1",
@@ -5121,6 +5122,39 @@
       },
       "peerDependencies": {
         "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^1.1.1",

--- a/src/components/Table/PLAN.md
+++ b/src/components/Table/PLAN.md
@@ -1,6 +1,11 @@
 # Table Component — Implementation Plan
 
-Status: **v1 implemented** · Owner: TBD · Branch: `feat/table-component`
+Status: **v1 implemented (internal / unreleased)** · Owner: TBD · Branch: `feat/table-component`
+
+> Landed but intentionally **not part of the public API yet**: the root barrel export in
+> `src/index.ts` is commented out and both Storybook stories carry `tags: ['!dev']` (hidden
+> from the sidebar), matching the `Command` / `TagInput` convention. Re-enable both when it's
+> ready to ship.
 
 > v1 shipped on this branch: semantic primitives + `Table<T>`, column grouping,
 > row headers, sorting (`aria-sort` + live announcements), visual row-group sections

--- a/src/components/Table/PLAN.md
+++ b/src/components/Table/PLAN.md
@@ -1,0 +1,279 @@
+# Table Component — Implementation Plan
+
+Status: **v1 implemented** · Owner: TBD · Branch: `feat/table-component`
+
+> v1 shipped on this branch: semantic primitives + `Table<T>`, column grouping,
+> row headers, sorting (`aria-sort` + live announcements), visual row-group sections
+> (primitives), scroll + stacked responsive modes, style variants, Storybook stories with
+> `?raw` demos, and `vitest-axe` + interaction tests (all green; ~89 KB brotlied). Manual
+> screen-reader passes (esp. stacked mode) still recommended per the §7 checklist.
+
+A full-class, 508-compliant Table component for `@capitaltg/vero`, styled like the
+[USWDS Table](https://designsystem.digital.gov/components/table/) using Tailwind + Vero
+design tokens, with all machinery powered by
+[TanStack Table](https://tanstack.com/table) (`@tanstack/react-table`).
+
+> This is a living document. v1 is settled; v2+ is a backlog to iterate on _after_ v1 lands.
+
+---
+
+## 1. Principles (apply to every phase)
+
+- **Accessibility / 508 compliance is the primary product.** Every feature ships with an
+  a11y story and passing `vitest-axe` assertions before it's considered done.
+- **Native `<table>` semantics by default.** Real `<table>/<thead>/<tbody>/<tr>/<th>/<td>`.
+  We only reach for `role="grid"`/`treegrid` when we add interactive cell-level keyboard
+  navigation or interactive tree/row grouping (an explicit, later, opt-in feature).
+- **USWDS look via Vero tokens.** Style with cva + `cn` + `styles.*`, using the semantic
+  scales and role tokens in `src/styles/theme.css` / `tailwind.config.js`. Styling is
+  expected to change later — keep it isolated in cva definitions so a re-theme is cheap.
+- **Match Vero conventions exactly.** Folder layout, `forwardRef` + `displayName`,
+  generic-over-`<T>` forwardRef cast (see `Autocomplete`), flat compound exports (see
+  `Dialog`), `vero-table` marker class, `@/` imports, JSDoc on every prop.
+- **Storybook is a first-class deliverable.** Dedicated stories for _every_ feature and
+  variant (see §4). Stories are how we build, review, and document this — for us and for
+  consuming devs.
+
+---
+
+## 2. Architecture — Hybrid API
+
+Two layers over one shared rendering surface:
+
+### Layer 1 — Semantic primitives (dumb, styled, composable)
+
+Styled wrappers around native table elements. Used directly for small/static/bespoke
+tables; also the render target for `Table`.
+
+- `TableRoot` — `<table>` + scrollable/stacked responsive wrapper, `vero-table` marker
+- `TableCaption` — `<caption>` (supports visually-hidden)
+- `TableHeader` — `<thead>`
+- `TableBody` — `<tbody>` (multiple allowed → visual row-group sections)
+- `TableFooter` — `<tfoot>`
+- `TableRow` — `<tr>`
+- `TableHead` — `<th>`; `scope` prop (`col | row | colgroup | rowgroup`), sort affordance hooks
+- `TableCell` — `<td>`; optional `data-label` for stacked mode
+
+Exported flat, like Dialog: `TableRoot, TableCaption, TableHeader, TableBody, TableFooter,
+TableRow, TableHead, TableCell`. (The config-driven component below takes the bare `Table`
+name; the primitive `<table>` wrapper is `TableRoot`.)
+
+### Layer 2 — `Table<T>` (config-driven, TanStack-powered)
+
+```tsx
+<Table data={rows} columns={columns} caption="…" />
+```
+
+Runs `useReactTable` internally, renders through the Layer-1 primitives via `flexRender`.
+Generic over `<T>` using the `Autocomplete` forwardRef-cast pattern. All v1 features below
+are configured through `columns` (`ColumnDef[]`) + `Table` props + slot render props.
+
+**Interchange rule:** the two layers share a render layer but are not mixed mid-table. You
+either compose primitives yourself _or_ drive a `Table` and customize via its seams
+(`ColumnDef.cell` renderers, `meta`, and slot props for caption/footer/toolbar/empty state).
+
+---
+
+## 3. File layout (matches Vero conventions)
+
+```
+src/components/Table/
+  index.ts                      # flat barrel: Table + TableRoot primitives + types
+  types.ts                      # TableProps<T> (config), TableRootProps (primitive), ColumnMeta augmentation, etc.
+  constants.ts                  # cva definitions (tableVariants) + stacked-mode class maps
+  PLAN.md                       # this document (remove or relocate before public release)
+  src/
+    TableRoot.tsx               # primitives (TableRoot + TableHeader/Body/Row/Head/Cell/…)
+    Table.tsx                   # config-driven component (TanStack-powered)
+    TableRoot.test.tsx          # primitives tests
+    Table.test.tsx              # config-driven tests
+  stories/
+    TableRoot.stories.tsx       # primitives + composed examples
+    Table.stories.tsx           # config-driven examples (one story per feature)
+  demos/
+    TableRoot*.tsx / Table*.tsx # one file per story example, shown as source via ?raw
+```
+
+- Add `export * from './components/Table'` to `src/index.ts` (alphabetical: between
+  `SwitchGroup` and `Tabs`).
+- Augment TanStack's `ColumnMeta` interface (module augmentation in `types.ts`) with
+  `isRowHeader?`, `align?`, `stackedLabel?`, etc.
+- New dependency: `@tanstack/react-table` (~13–15 KB gzipped, tree-shakeable — within the
+  150 KB `size-limit` budget). Add to `dependencies`.
+
+---
+
+## 4. Storybook strategy (first-class)
+
+**Rule: every feature and every variant gets its own dedicated, named story.** Stories use
+the Vero `demos/` + `?raw` pattern so each example renders live _and_ shows its source.
+`@storybook/addon-a11y` runs on all of them.
+
+Baseline story set (grows with each phase):
+
+- `TableRoot` (primitives): Default, WithCaption, RowHeaders, ColumnGroups (multi-level
+  headers), RowGroupSections, Borderless/Striped/Compact style variants, Scrollable,
+  Stacked.
+- `Table` (config-driven): Default, Sortable, ColumnGroups, RowHeaders, RowGroupSections,
+  Scrollable, Stacked, EmptyState, CustomCellRenderers.
+- A dedicated **Accessibility** story per component demonstrating caption, `scope`,
+  `aria-sort`, and the live-region announcement, with notes for consuming devs.
+
+Each phase below lists the stories it must add.
+
+---
+
+## 5. v1 — The accessible foundation ✅ (build now)
+
+### 5.1 Primitives
+
+Semantic, styled Layer-1 components (§2). USWDS style variants via cva: default, striped,
+borderless, compact; optional `stickyHeader`.
+
+### 5.2 `Table<T>`
+
+`data` + `columns` → `useReactTable` → primitives via `flexRender`. Slot props:
+`caption`, `emptyState`, `footer`.
+
+### 5.3 Caption / accessible name
+
+`<caption>` always available (via `TableCaption` or `Table`'s `caption` prop).
+Support visually-hidden captions (`styles`-based `sr-only`) so a table can be named for AT
+without a visible title. **A table must always have an accessible name.**
+
+### 5.4 Row headers
+
+`<th scope="row">` for the row's header cell. In `Table`, designate via
+`ColumnDef.meta.isRowHeader`. Primitives: consumer sets `scope="row"` on `TableHead`.
+
+### 5.5 Column grouping (multi-level headers)
+
+Nested `columns` in `ColumnDef` → TanStack header groups → multiple `<tr>` in `<thead>`
+with correct `colSpan` and `scope="colgroup"` on spanning headers.
+
+### 5.6 Column sorting
+
+- TanStack `getSortedRowModel`, `sortingState`.
+- Header renders a real `<button>` inside the `<th>`; `<th>` carries
+  `aria-sort="ascending|descending|none"`.
+- Sort direction icon (lucide `ChevronUp`/`ChevronDown`/`ChevronsUpDown`).
+- `aria-live="polite"` `.sr-only` status region announces the new sort (column + direction),
+  following the Autocomplete announcement pattern.
+- Per-column opt-in/out; tri-state (asc → desc → none) configurable.
+
+### 5.7 Visual row-group sections
+
+Multiple `<tbody>` sections, each introduced by a group-header row using
+`<th scope="colgroup">` (or `rowgroup` as appropriate). **Static only** — no collapse, no
+aggregation in v1. Supported in primitives directly; `Table` helper to derive sections
+from a grouping key (render-only, not TanStack `getGroupedRowModel`).
+
+### 5.8 Responsive
+
+- **Scrollable (default, always on):** focusable scroll container — `role="region"`,
+  `tabindex="0"`, `aria-label` (derived from caption), visible focus ring. Works for any
+  table.
+- **Stacked (opt-in, `responsive="stack"`):** below a breakpoint each row becomes a card;
+  each cell shows its column header via `data-label`. **`Table` populates `data-label`
+  automatically** (it knows the headers). Primitive-path stacked requires the consumer to
+  pass `data-label`/`stackedLabel` per cell — documented, lower priority.
+
+### 5.9 Testing (v1)
+
+- `vitest-axe` `expectNoViolations` for: default, with caption, row headers, column groups,
+  row-group sections, sorted (each direction), scrollable, stacked, empty state.
+- Interaction tests (user-event): clicking a sort header toggles `aria-sort` and updates
+  order; live region announces; keyboard activation of sort button.
+- Contract tests: `scope` values correct; `role="region"` + `aria-label` present on scroll
+  wrapper; row-header `<th scope="row">` rendered where designated.
+
+### 5.10 Stories (v1)
+
+All baseline stories in §4 that don't depend on a later phase.
+
+---
+
+## 6. v2+ — Backlog (iterate after v1)
+
+Each item is a clean add-on because the render layer is stable. Each ships with its own
+stories and axe coverage. Rough priority order:
+
+### Phase 2 — Interaction essentials
+
+- **Row selection.** Checkbox column using Vero `Checkbox`; select-all in header;
+  `aria-selected` where semantically appropriate; announce selection count. Indeterminate
+  select-all state.
+- **Pagination.** Client-side `getPaginationRowModel`; accessible page controls (reuse/align
+  with any Vero Pagination); announce page changes; page-size select.
+- **Filtering / global search.** Column filters + optional global search box; result-count
+  announcements; clear affordance. Debounced.
+
+Stories: RowSelection, SelectAll, Pagination, PageSizes, ColumnFilters, GlobalSearch.
+
+### Phase 3 — Advanced grouping
+
+- **Collapsible aggregated groups.** TanStack `getGroupedRowModel` + aggregation
+  (count/sum/avg/custom). Expand/collapse with `aria-expanded`, focus management, and
+  announcements. Decide `treegrid` vs native semantics here.
+- **Expandable detail rows.** `getExpandedRowModel` master-detail; expander button a11y;
+  detail row association.
+
+Stories: GroupedAggregated, GroupedCollapsible, ExpandableRows, MasterDetail.
+
+### Phase 4 — Column management
+
+- Column resizing (keyboard-operable handles, `aria-label`).
+- Column reordering (accessible drag alternative / keyboard move).
+- Column pinning (left/right) + sticky columns.
+- Column visibility toggle menu.
+
+Stories: ResizableColumns, ReorderColumns, PinnedColumns, ColumnVisibility.
+
+### Phase 5 — Scale & interaction depth
+
+- **`role="grid"` keyboard cell navigation** (arrow keys, Home/End, PageUp/Down, roving
+  tabindex) — opt-in, for spreadsheet-like tables.
+- **Virtualization** (`@tanstack/react-virtual`) for large datasets, with an a11y-safe
+  strategy (row count semantics, focus retention).
+- Sticky header refinements; sticky first column.
+
+Stories: KeyboardGridNav, VirtualizedRows, StickyHeaderAndColumn.
+
+### Phase 6 — Nice-to-haves
+
+- Editable cells (inline edit a11y).
+- Server-side data mode (manual sorting/pagination/filtering; loading + skeleton states;
+  announce loading).
+- Export (CSV) affordance.
+- Density toggle control.
+- Custom empty / error / loading slots standardized.
+
+Stories: EditableCells, ServerSideData, LoadingStates, DensityToggle.
+
+---
+
+## 7. Accessibility checklist (living)
+
+- [ ] Every table has an accessible name (`<caption>` or `aria-label`/`aria-labelledby`).
+- [ ] `<th>` with correct `scope` (`col`/`row`/`colgroup`/`rowgroup`) everywhere.
+- [ ] Sortable headers: `<button>` + `aria-sort`; live-region announcement.
+- [ ] Scroll container: `role="region"`, `tabindex="0"`, `aria-label`, visible focus.
+- [ ] Stacked mode: each cell labeled with its column header.
+- [ ] Color is never the only signal (sort direction, selection, groups also use icon/text).
+- [ ] Contrast meets WCAG AA against Vero tokens in default + `.dark` + `.theme-uswds`.
+- [ ] All interactive affordances are keyboard-operable with visible focus.
+- [ ] `vitest-axe` passes for every story/state.
+- [ ] Manual screen-reader smoke test (VoiceOver / NVDA) per phase.
+
+---
+
+## 8. Open questions / decisions to revisit
+
+- Primitive-path stacked mode: ship in v1 (consumer supplies labels) or defer entirely?
+  _Current: defer; `Table` stacked only in v1._
+- Do we align pagination with a future dedicated Vero `Pagination` component, or build
+  table-local controls first? (Phase 2 decision.)
+- When we add collapsible grouping/expansion: native semantics vs `treegrid`. (Phase 3.)
+- Should style variants (striped/compact/borderless) be cva variants on `TableRoot`, or a
+  theme-level concern? _Current: cva variants._
+- Final home for this PLAN.md before public release (docs site vs delete).

--- a/src/components/Table/constants.ts
+++ b/src/components/Table/constants.ts
@@ -1,0 +1,92 @@
+import { tw } from '@/lib/utils';
+import { cva } from 'class-variance-authority';
+import type { TableStackBreakpoint } from './types';
+
+/**
+ * USWDS-inspired styling for the `<table>` root. Structural rules are applied
+ * with descendant selectors so the semantic primitives stay thin and the whole
+ * look can be re-themed from one place.
+ *
+ * Colors use theme-adaptive tokens where possible (`muted`, `foreground`,
+ * `input`) so the table works in the default, `.dark`, and `.theme-uswds`
+ * themes. Grid lines use `base-500` (a mid gray) so they remain visible on both
+ * light and dark surfaces.
+ */
+export const tableVariants = cva(
+  tw`vero-table [&_tbody_th]:bg-muted/40 w-full border-collapse text-left align-top text-sm
+  text-foreground [&_caption]:mb-3 [&_caption]:text-left [&_caption]:text-base [&_caption]:font-bold
+  [&_caption]:text-foreground [&_tbody_th]:text-left [&_tbody_th]:align-middle [&_td]:px-4
+  [&_td]:py-2 [&_td]:align-top [&_th]:px-4 [&_th]:py-2 [&_th]:text-left [&_th]:align-bottom
+  [&_th]:font-bold [&_thead_th]:bg-muted [&_thead_th]:text-foreground`,
+  {
+    variants: {
+      variant: {
+        bordered: tw`[&_td]:border [&_td]:border-base-500 [&_th]:border [&_th]:border-base-500`,
+        borderless: tw`[&_tbody_td]:border-b [&_tbody_td]:border-input [&_tbody_th]:border-b
+        [&_tbody_th]:border-input [&_tbody_th]:bg-transparent [&_td]:border-0 [&_th]:border-0
+        [&_thead_th]:border-b-2 [&_thead_th]:border-base-500 [&_thead_th]:bg-transparent`,
+      },
+      striped: {
+        true: tw`[&_tbody_tr:nth-child(even)_td]:bg-muted/50`,
+        false: '',
+      },
+      density: {
+        default: '',
+        compact: tw`text-[0.8125rem] [&_td]:px-3 [&_td]:py-1 [&_th]:px-3 [&_th]:py-1`,
+      },
+    },
+    defaultVariants: {
+      variant: 'bordered',
+      striped: false,
+      density: 'default',
+    },
+  },
+);
+
+/**
+ * Card/stacked reflow, applied to the `<table>` root when
+ * `responsive="stack"`. Rules are gated behind `max-*` (max-width) variants so
+ * they apply ONLY below the breakpoint and leave the normal grid — and its
+ * variant borders — untouched at and above it.
+ *
+ * Below the breakpoint the header row is hidden and each cell is laid out as a
+ * label/value pair; {@link Table} renders a visible per-cell label so the
+ * data stays perceivable.
+ */
+export const tableStackVariants: Record<TableStackBreakpoint, string> = {
+  sm: tw`max-sm:[&_tbody_td]:flex max-sm:[&_tbody_td]:justify-between max-sm:[&_tbody_td]:gap-4
+  max-sm:[&_tbody_td]:border-0 max-sm:[&_tbody_td]:border-b max-sm:[&_tbody_td]:border-input
+  max-sm:[&_tbody_td]:text-right max-sm:[&_tbody_th]:flex max-sm:[&_tbody_th]:justify-between
+  max-sm:[&_tbody_th]:gap-4 max-sm:[&_tbody_th]:border-0 max-sm:[&_tbody_th]:border-b
+  max-sm:[&_tbody_th]:border-input max-sm:[&_tbody_th]:bg-transparent max-sm:[&_tbody_th]:text-right
+  max-sm:[&_tbody_tr:last-child]:mb-0 max-sm:[&_tbody_tr>*:last-child]:border-b-0
+  max-sm:[&_tbody_tr]:mb-4 max-sm:[&_tbody_tr]:block max-sm:[&_tbody_tr]:border
+  max-sm:[&_tbody_tr]:border-base-500 max-sm:[&_thead]:hidden`,
+  md: tw`max-md:[&_tbody_td]:flex max-md:[&_tbody_td]:justify-between max-md:[&_tbody_td]:gap-4
+  max-md:[&_tbody_td]:border-0 max-md:[&_tbody_td]:border-b max-md:[&_tbody_td]:border-input
+  max-md:[&_tbody_td]:text-right max-md:[&_tbody_th]:flex max-md:[&_tbody_th]:justify-between
+  max-md:[&_tbody_th]:gap-4 max-md:[&_tbody_th]:border-0 max-md:[&_tbody_th]:border-b
+  max-md:[&_tbody_th]:border-input max-md:[&_tbody_th]:bg-transparent max-md:[&_tbody_th]:text-right
+  max-md:[&_tbody_tr:last-child]:mb-0 max-md:[&_tbody_tr>*:last-child]:border-b-0
+  max-md:[&_tbody_tr]:mb-4 max-md:[&_tbody_tr]:block max-md:[&_tbody_tr]:border
+  max-md:[&_tbody_tr]:border-base-500 max-md:[&_thead]:hidden`,
+  lg: tw`max-lg:[&_tbody_td]:flex max-lg:[&_tbody_td]:justify-between max-lg:[&_tbody_td]:gap-4
+  max-lg:[&_tbody_td]:border-0 max-lg:[&_tbody_td]:border-b max-lg:[&_tbody_td]:border-input
+  max-lg:[&_tbody_td]:text-right max-lg:[&_tbody_th]:flex max-lg:[&_tbody_th]:justify-between
+  max-lg:[&_tbody_th]:gap-4 max-lg:[&_tbody_th]:border-0 max-lg:[&_tbody_th]:border-b
+  max-lg:[&_tbody_th]:border-input max-lg:[&_tbody_th]:bg-transparent max-lg:[&_tbody_th]:text-right
+  max-lg:[&_tbody_tr:last-child]:mb-0 max-lg:[&_tbody_tr>*:last-child]:border-b-0
+  max-lg:[&_tbody_tr]:mb-4 max-lg:[&_tbody_tr]:block max-lg:[&_tbody_tr]:border
+  max-lg:[&_tbody_tr]:border-base-500 max-lg:[&_thead]:hidden`,
+};
+
+/**
+ * Visibility classes for the per-cell stacked label (shown below the
+ * breakpoint, hidden at and above it). Kept as literal strings so Tailwind's
+ * content scanner picks them up.
+ */
+export const tableStackLabelVisibility: Record<TableStackBreakpoint, string> = {
+  sm: tw`hidden max-sm:block`,
+  md: tw`hidden max-md:block`,
+  lg: tw`hidden max-lg:block`,
+};

--- a/src/components/Table/demos/TableColumnGroups.tsx
+++ b/src/components/Table/demos/TableColumnGroups.tsx
@@ -1,0 +1,10 @@
+import { Table } from '../src/Table';
+import { groupedPersonColumns, people } from './sampleData';
+
+/**
+ * Nested `columns` in the column definitions produce multi-level headers, with
+ * the correct `colSpan` and `scope="colgroup"` applied automatically.
+ */
+export const TableColumnGroups = () => (
+  <Table caption="Team roster (grouped columns)" columns={groupedPersonColumns} data={people} />
+);

--- a/src/components/Table/demos/TableDefault.tsx
+++ b/src/components/Table/demos/TableDefault.tsx
@@ -1,0 +1,11 @@
+import { Table } from '../src/Table';
+import { people, personColumns } from './sampleData';
+
+/**
+ * The config-driven `Table`: pass `data` + `columns` and it renders through
+ * the semantic primitives. The `name` column is the row header (via
+ * `meta.isRowHeader`) and the salary column is right-aligned (`meta.align`).
+ */
+export const TableDefault = () => (
+  <Table caption="Team roster" columns={personColumns} data={people} />
+);

--- a/src/components/Table/demos/TableEmpty.tsx
+++ b/src/components/Table/demos/TableEmpty.tsx
@@ -1,0 +1,12 @@
+import { Table } from '../src/Table';
+import { personColumns, type Person } from './sampleData';
+
+/** When `data` is empty, the `emptyState` content spans the full width. */
+export const TableEmpty = () => (
+  <Table
+    caption="Team roster"
+    columns={personColumns}
+    data={[] as Person[]}
+    emptyState="No team members found."
+  />
+);

--- a/src/components/Table/demos/TableRootBasic.tsx
+++ b/src/components/Table/demos/TableRootBasic.tsx
@@ -1,0 +1,48 @@
+import {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../src/TableRoot';
+
+/**
+ * A small, static table composed from the primitives — no `data`/`columns`
+ * config needed. Note `scope="col"` on the column headers and `scope="row"` on
+ * the first cell of each body row.
+ */
+export const TableRootBasic = () => (
+  <TableRoot aria-label="Quarterly revenue">
+    <TableCaption>Quarterly revenue</TableCaption>
+    <TableHeader>
+      <TableRow>
+        <TableHead scope="col">Quarter</TableHead>
+        <TableHead className="text-right" scope="col">
+          Revenue
+        </TableHead>
+        <TableHead className="text-right" scope="col">
+          Change
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableHead scope="row">Q1</TableHead>
+        <TableCell className="text-right">$1.2M</TableCell>
+        <TableCell className="text-right">+4%</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableHead scope="row">Q2</TableHead>
+        <TableCell className="text-right">$1.4M</TableCell>
+        <TableCell className="text-right">+17%</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableHead scope="row">Q3</TableHead>
+        <TableCell className="text-right">$1.3M</TableCell>
+        <TableCell className="text-right">−7%</TableCell>
+      </TableRow>
+    </TableBody>
+  </TableRoot>
+);

--- a/src/components/Table/demos/TableRootColumnGroups.tsx
+++ b/src/components/Table/demos/TableRootColumnGroups.tsx
@@ -1,0 +1,62 @@
+import {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../src/TableRoot';
+
+/**
+ * Multi-level column headers. Group headers span their child columns with
+ * `colSpan` and use `scope="colgroup"`; the leaf headers use `scope="col"`.
+ */
+export const TableRootColumnGroups = () => (
+  <TableRoot aria-label="Regional sales by half">
+    <TableCaption>Regional sales by half</TableCaption>
+    <TableHeader>
+      <TableRow>
+        <TableHead rowSpan={2} scope="col">
+          Region
+        </TableHead>
+        <TableHead className="text-center" colSpan={2} scope="colgroup">
+          First half
+        </TableHead>
+        <TableHead className="text-center" colSpan={2} scope="colgroup">
+          Second half
+        </TableHead>
+      </TableRow>
+      <TableRow>
+        <TableHead className="text-right" scope="col">
+          Q1
+        </TableHead>
+        <TableHead className="text-right" scope="col">
+          Q2
+        </TableHead>
+        <TableHead className="text-right" scope="col">
+          Q3
+        </TableHead>
+        <TableHead className="text-right" scope="col">
+          Q4
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableHead scope="row">North</TableHead>
+        <TableCell className="text-right">$120k</TableCell>
+        <TableCell className="text-right">$140k</TableCell>
+        <TableCell className="text-right">$132k</TableCell>
+        <TableCell className="text-right">$158k</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableHead scope="row">South</TableHead>
+        <TableCell className="text-right">$98k</TableCell>
+        <TableCell className="text-right">$112k</TableCell>
+        <TableCell className="text-right">$105k</TableCell>
+        <TableCell className="text-right">$121k</TableCell>
+      </TableRow>
+    </TableBody>
+  </TableRoot>
+);

--- a/src/components/Table/demos/TableRootRowGroups.tsx
+++ b/src/components/Table/demos/TableRootRowGroups.tsx
@@ -1,0 +1,56 @@
+import {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../src/TableRoot';
+
+/**
+ * Visual row-group sections. Each `<TableBody>` is a section introduced by a
+ * spanning group header (`scope="colgroup"`). Static grouping — no collapsing
+ * or aggregation (those are planned for a later phase).
+ */
+export const TableRootRowGroups = () => (
+  <TableRoot aria-label="Employees by department">
+    <TableCaption>Employees by department</TableCaption>
+    <TableHeader>
+      <TableRow>
+        <TableHead scope="col">Name</TableHead>
+        <TableHead scope="col">Role</TableHead>
+        <TableHead scope="col">Location</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableHead className="bg-muted" colSpan={3} scope="colgroup">
+          Engineering
+        </TableHead>
+      </TableRow>
+      <TableRow>
+        <TableHead scope="row">Ada Lovelace</TableHead>
+        <TableCell>Engineer</TableCell>
+        <TableCell>London</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableHead scope="row">Grace Hopper</TableHead>
+        <TableCell>Engineer</TableCell>
+        <TableCell>New York</TableCell>
+      </TableRow>
+    </TableBody>
+    <TableBody>
+      <TableRow>
+        <TableHead className="bg-muted" colSpan={3} scope="colgroup">
+          Research
+        </TableHead>
+      </TableRow>
+      <TableRow>
+        <TableHead scope="row">Alan Turing</TableHead>
+        <TableCell>Researcher</TableCell>
+        <TableCell>Manchester</TableCell>
+      </TableRow>
+    </TableBody>
+  </TableRoot>
+);

--- a/src/components/Table/demos/TableRootStyleVariants.tsx
+++ b/src/components/Table/demos/TableRootStyleVariants.tsx
@@ -1,0 +1,52 @@
+import {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../src/TableRoot';
+import type { TableRootProps } from '../types';
+
+const rows = [
+  { fruit: 'Apples', qty: 12, price: '$0.50' },
+  { fruit: 'Bananas', qty: 8, price: '$0.25' },
+  { fruit: 'Cherries', qty: 30, price: '$0.10' },
+];
+
+const Sample = ({ label, ...props }: { label: string } & TableRootProps) => (
+  <TableRoot aria-label={label} responsive="none" {...props}>
+    <TableCaption>{label}</TableCaption>
+    <TableHeader>
+      <TableRow>
+        <TableHead scope="col">Fruit</TableHead>
+        <TableHead className="text-right" scope="col">
+          Qty
+        </TableHead>
+        <TableHead className="text-right" scope="col">
+          Price
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {rows.map(row => (
+        <TableRow key={row.fruit}>
+          <TableHead scope="row">{row.fruit}</TableHead>
+          <TableCell className="text-right">{row.qty}</TableCell>
+          <TableCell className="text-right">{row.price}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </TableRoot>
+);
+
+/** The `variant`, `striped`, and `density` style options. */
+export const TableRootStyleVariants = () => (
+  <div className="flex flex-col gap-8">
+    <Sample label="Bordered (default)" />
+    <Sample striped label="Striped" />
+    <Sample label="Borderless" variant="borderless" />
+    <Sample density="compact" label="Compact" />
+  </div>
+);

--- a/src/components/Table/demos/TableScrollable.tsx
+++ b/src/components/Table/demos/TableScrollable.tsx
@@ -1,0 +1,96 @@
+import type { ColumnDef } from '@tanstack/react-table';
+import { Table } from '../src/Table';
+
+interface Metric {
+  month: string;
+  visitors: number;
+  signups: number;
+  active: number;
+  churn: number;
+  revenue: number;
+  refunds: number;
+}
+
+const data: Metric[] = [
+  {
+    month: 'January',
+    visitors: 12400,
+    signups: 820,
+    active: 9600,
+    churn: 120,
+    revenue: 48200,
+    refunds: 900,
+  },
+  {
+    month: 'February',
+    visitors: 13850,
+    signups: 910,
+    active: 10250,
+    churn: 140,
+    revenue: 52100,
+    refunds: 1100,
+  },
+  {
+    month: 'March',
+    visitors: 15020,
+    signups: 1040,
+    active: 11100,
+    churn: 160,
+    revenue: 57800,
+    refunds: 750,
+  },
+];
+
+const num = (n: number) => n.toLocaleString('en-US');
+
+const columns: ColumnDef<Metric, unknown>[] = [
+  { accessorKey: 'month', header: 'Month', meta: { isRowHeader: true } },
+  {
+    accessorKey: 'visitors',
+    header: 'Visitors',
+    meta: { align: 'right' },
+    cell: i => num(i.getValue<number>()),
+  },
+  {
+    accessorKey: 'signups',
+    header: 'Sign-ups',
+    meta: { align: 'right' },
+    cell: i => num(i.getValue<number>()),
+  },
+  {
+    accessorKey: 'active',
+    header: 'Active users',
+    meta: { align: 'right' },
+    cell: i => num(i.getValue<number>()),
+  },
+  {
+    accessorKey: 'churn',
+    header: 'Churned',
+    meta: { align: 'right' },
+    cell: i => num(i.getValue<number>()),
+  },
+  {
+    accessorKey: 'revenue',
+    header: 'Revenue',
+    meta: { align: 'right' },
+    cell: i => `$${num(i.getValue<number>())}`,
+  },
+  {
+    accessorKey: 'refunds',
+    header: 'Refunds',
+    meta: { align: 'right' },
+    cell: i => `$${num(i.getValue<number>())}`,
+  },
+];
+
+/**
+ * Scrollable mode (the default). When the table is wider than its container it
+ * gets a keyboard-focusable, labeled horizontal scroll region so keyboard-only
+ * users can reach the off-screen columns. The wrapper is constrained here to
+ * force the overflow.
+ */
+export const TableScrollable = () => (
+  <div className="max-w-xl">
+    <Table caption="Monthly metrics" columns={columns} data={data} />
+  </div>
+);

--- a/src/components/Table/demos/TableSortable.tsx
+++ b/src/components/Table/demos/TableSortable.tsx
@@ -1,0 +1,18 @@
+import { Table } from '../src/Table';
+import { people, personColumns } from './sampleData';
+
+/**
+ * Sorting enabled. Each sortable header is a real `<button>`; the `<th>` carries
+ * `aria-sort`, and sort changes are announced via a polite live region. Click a
+ * header (or focus it and press Enter/Space) to cycle ascending → descending →
+ * unsorted.
+ */
+export const TableSortable = () => (
+  <Table
+    enableSorting
+    caption="Team roster (sortable)"
+    columns={personColumns}
+    data={people}
+    initialSorting={[{ id: 'name', desc: false }]}
+  />
+);

--- a/src/components/Table/demos/TableStacked.tsx
+++ b/src/components/Table/demos/TableStacked.tsx
@@ -1,0 +1,22 @@
+import { Table } from '../src/Table';
+import { people, personColumns } from './sampleData';
+
+/**
+ * Stacked (card) mode. Below the `stackBreakpoint` (default `md`) each row
+ * collapses into a card and every cell is prefixed with its column label, so
+ * the data stays perceivable without horizontal scrolling. Resize the preview
+ * narrow to see it reflow.
+ *
+ * Note: below the breakpoint the grid's row/column semantics are traded for the
+ * card layout, so the per-cell labels carry the meaning. Prefer this mode for
+ * record-style data; use `responsive="scroll"` for wide/numeric tables.
+ */
+export const TableStacked = () => (
+  <Table
+    caption="Team roster (stacked on narrow screens)"
+    columns={personColumns}
+    data={people}
+    responsive="stack"
+    stackBreakpoint="md"
+  />
+);

--- a/src/components/Table/demos/sampleData.tsx
+++ b/src/components/Table/demos/sampleData.tsx
@@ -1,0 +1,88 @@
+import type { ColumnDef } from '@tanstack/react-table';
+
+export interface Person {
+  name: string;
+  role: string;
+  location: string;
+  startDate: string;
+  salary: number;
+}
+
+export const people: Person[] = [
+  {
+    name: 'Ada Lovelace',
+    role: 'Engineer',
+    location: 'London',
+    startDate: '2019-03-11',
+    salary: 145000,
+  },
+  {
+    name: 'Alan Turing',
+    role: 'Researcher',
+    location: 'Manchester',
+    startDate: '2017-06-23',
+    salary: 162000,
+  },
+  {
+    name: 'Grace Hopper',
+    role: 'Engineer',
+    location: 'New York',
+    startDate: '2015-12-09',
+    salary: 158000,
+  },
+  {
+    name: 'Katherine Johnson',
+    role: 'Analyst',
+    location: 'Hampton',
+    startDate: '2018-08-26',
+    salary: 139000,
+  },
+  {
+    name: 'Mary Jackson',
+    role: 'Engineer',
+    location: 'Hampton',
+    startDate: '2020-04-09',
+    salary: 141000,
+  },
+];
+
+const currency = (value: number) =>
+  value.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+/** Flat columns. The `name` column is marked as the row header. */
+export const personColumns: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name', meta: { isRowHeader: true } },
+  { accessorKey: 'role', header: 'Role' },
+  { accessorKey: 'location', header: 'Location' },
+  { accessorKey: 'startDate', header: 'Start date' },
+  {
+    accessorKey: 'salary',
+    header: 'Salary',
+    meta: { align: 'right' },
+    cell: info => currency(info.getValue<number>()),
+  },
+];
+
+/** Grouped columns — produces multi-level column headers. */
+export const groupedPersonColumns: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name', meta: { isRowHeader: true } },
+  {
+    header: 'Employment',
+    columns: [
+      { accessorKey: 'role', header: 'Role' },
+      { accessorKey: 'startDate', header: 'Start date' },
+    ],
+  },
+  {
+    header: 'Location & pay',
+    columns: [
+      { accessorKey: 'location', header: 'Location' },
+      {
+        accessorKey: 'salary',
+        header: 'Salary',
+        meta: { align: 'right' },
+        cell: info => currency(info.getValue<number>()),
+      },
+    ],
+  },
+];

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,0 +1,23 @@
+export { Table } from './src/Table';
+export {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './src/TableRoot';
+
+export type {
+  TableProps,
+  TableCaptionProps,
+  TableCellProps,
+  TableHeadProps,
+  TableRootProps,
+  TableResponsive,
+  TableRowProps,
+  TableSectionProps,
+  TableStackBreakpoint,
+} from './types';

--- a/src/components/Table/src/Table.test.tsx
+++ b/src/components/Table/src/Table.test.tsx
@@ -1,0 +1,113 @@
+import { expectNoViolations } from '@/test/utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { groupedPersonColumns, people, personColumns, type Person } from '../demos/sampleData';
+import { Table } from './Table';
+
+describe('Table', () => {
+  describe('Accessibility', () => {
+    it('has no violations with a caption', async () => {
+      const { container } = render(
+        <Table caption="Team roster" columns={personColumns} data={people} />,
+      );
+      expectNoViolations(await axe(container));
+    });
+
+    it('has no violations when sortable', async () => {
+      const { container } = render(
+        <Table enableSorting caption="Team roster" columns={personColumns} data={people} />,
+      );
+      expectNoViolations(await axe(container));
+    });
+
+    it('has no violations with grouped columns', async () => {
+      const { container } = render(
+        <Table caption="Team roster" columns={groupedPersonColumns} data={people} />,
+      );
+      expectNoViolations(await axe(container));
+    });
+
+    it('has no violations in stacked mode', async () => {
+      const { container } = render(
+        <Table caption="Team roster" columns={personColumns} data={people} responsive="stack" />,
+      );
+      expectNoViolations(await axe(container));
+    });
+
+    it('has no violations when empty', async () => {
+      const { container } = render(
+        <Table caption="Team roster" columns={personColumns} data={[] as Person[]} />,
+      );
+      expectNoViolations(await axe(container));
+    });
+  });
+
+  it('marks the isRowHeader column as a row header', () => {
+    render(<Table caption="Team roster" columns={personColumns} data={people} />);
+    const ada = screen.getByRole('rowheader', { name: 'Ada Lovelace' });
+    expect(ada.tagName).toBe('TH');
+    expect(ada).toHaveAttribute('scope', 'row');
+  });
+
+  it('applies scope="colgroup" to group headers', () => {
+    render(<Table caption="Team roster" columns={groupedPersonColumns} data={people} />);
+    const group = screen.getByRole('columnheader', { name: 'Employment' });
+    expect(group).toHaveAttribute('scope', 'colgroup');
+    expect(group).toHaveAttribute('colspan', '2');
+  });
+
+  it('renders the empty state spanning all columns', () => {
+    render(
+      <Table
+        caption="Team roster"
+        columns={personColumns}
+        data={[] as Person[]}
+        emptyState="No team members found."
+      />,
+    );
+    const cell = screen.getByText('No team members found.');
+    expect(cell).toHaveAttribute('colspan', String(personColumns.length));
+  });
+
+  describe('sorting', () => {
+    it('does not render sort controls when sorting is disabled', () => {
+      render(<Table caption="Team roster" columns={personColumns} data={people} />);
+      expect(screen.queryByRole('button', { name: 'Role' })).not.toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Role' })).not.toHaveAttribute('aria-sort');
+    });
+
+    it('cycles aria-sort ascending → descending → none and announces the change', async () => {
+      const user = userEvent.setup();
+      render(<Table enableSorting caption="Team roster" columns={personColumns} data={people} />);
+
+      const header = screen.getByRole('columnheader', { name: 'Role' });
+      const button = screen.getByRole('button', { name: 'Role' });
+      const status = screen.getByRole('status');
+
+      expect(header).toHaveAttribute('aria-sort', 'none');
+
+      await user.click(button);
+      expect(header).toHaveAttribute('aria-sort', 'ascending');
+      expect(status).toHaveTextContent('Sorted by Role, ascending');
+
+      await user.click(button);
+      expect(header).toHaveAttribute('aria-sort', 'descending');
+      expect(status).toHaveTextContent('Sorted by Role, descending');
+
+      await user.click(button);
+      expect(header).toHaveAttribute('aria-sort', 'none');
+      expect(status).toHaveTextContent('TableRoot is no longer sorted');
+    });
+
+    it('reorders rows when a column is sorted', async () => {
+      const user = userEvent.setup();
+      render(<Table enableSorting caption="Team roster" columns={personColumns} data={people} />);
+
+      await user.click(screen.getByRole('button', { name: 'Name' }));
+      const rowHeaders = screen.getAllByRole('rowheader').map(el => el.textContent);
+      expect(rowHeaders).toEqual([...rowHeaders].sort());
+    });
+  });
+});

--- a/src/components/Table/src/Table.tsx
+++ b/src/components/Table/src/Table.tsx
@@ -1,0 +1,285 @@
+import { styles } from '@/lib/styles';
+import { cn } from '@/lib/utils';
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type Column,
+  type OnChangeFn,
+  type SortingState,
+} from '@tanstack/react-table';
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react';
+import * as React from 'react';
+import { tableStackLabelVisibility } from '../constants';
+import type { TableProps } from '../types';
+import {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './TableRoot';
+
+const alignClass = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+} as const;
+
+const alignJustify = {
+  left: 'justify-start',
+  center: 'justify-center',
+  right: 'justify-end',
+} as const;
+
+/** Best-effort human label for a column (its string header, else its id). */
+function getColumnLabel<TData>(column: Column<TData, unknown>): string {
+  const header = column.columnDef.header;
+  return typeof header === 'string' ? header : column.id;
+}
+
+/** Label shown in front of a cell's value in stacked (card) mode. */
+function getStackLabel<TData>(column: Column<TData, unknown>): string {
+  return column.columnDef.meta?.stackedLabel ?? getColumnLabel(column);
+}
+
+function SortIcon({ state }: { state: false | 'asc' | 'desc' }) {
+  const Icon = state === 'asc' ? ArrowUp : state === 'desc' ? ArrowDown : ChevronsUpDown;
+  return (
+    <Icon aria-hidden="true" className={cn('ml-1 h-4 w-4 shrink-0', !state && 'opacity-50')} />
+  );
+}
+
+function TableInner<TData>(
+  {
+    data,
+    columns,
+    caption,
+    captionHidden = false,
+    enableSorting = false,
+    initialSorting,
+    sorting: controlledSorting,
+    onSortingChange,
+    responsive = 'scroll',
+    stackBreakpoint = 'md',
+    variant,
+    striped,
+    density,
+    emptyState = 'No data available',
+    footer,
+    getRowId,
+    className,
+    ...props
+  }: TableProps<TData>,
+  ref: React.ForwardedRef<HTMLTableElement>,
+) {
+  const ariaLabelProp = props['aria-label'];
+  const ariaLabelledby = props['aria-labelledby'];
+
+  const [internalSorting, setInternalSorting] = React.useState<SortingState>(initialSorting ?? []);
+  const isControlled = controlledSorting !== undefined;
+  const sorting = isControlled ? controlledSorting : internalSorting;
+
+  const handleSortingChange: OnChangeFn<SortingState> = React.useCallback(
+    updater => {
+      if (!isControlled) {
+        setInternalSorting(prev => (typeof updater === 'function' ? updater(prev) : updater));
+      }
+      onSortingChange?.(updater);
+    },
+    [isControlled, onSortingChange],
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    enableSorting,
+    onSortingChange: handleSortingChange,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
+    getRowId,
+  });
+
+  // Announce sort changes to screen readers via a polite live region.
+  const [announcement, setAnnouncement] = React.useState('');
+  const hasMounted = React.useRef(false);
+  React.useEffect(() => {
+    if (!enableSorting) return;
+    // Don't announce the initial (possibly pre-sorted) state on mount.
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+    if (sorting.length === 0) {
+      setAnnouncement('TableRoot is no longer sorted');
+      return;
+    }
+    const primary = sorting[0];
+    const column = table.getColumn(primary.id);
+    const label = column ? getColumnLabel(column) : primary.id;
+    setAnnouncement(`Sorted by ${label}, ${primary.desc ? 'descending' : 'ascending'}`);
+  }, [sorting, enableSorting, table]);
+
+  const rows = table.getRowModel().rows;
+  const leafColumnCount = table.getVisibleLeafColumns().length;
+
+  // Name the scroll region after the caption text (when it's a plain string) or
+  // an explicit aria-label. A non-string caption still names the <table> via
+  // <caption>; the region then stays a plain focusable scroll container.
+  const captionText = typeof caption === 'string' ? caption : undefined;
+  const regionLabel = ariaLabelProp ?? captionText;
+
+  return (
+    <>
+      <TableRoot
+        ref={ref}
+        aria-label={regionLabel}
+        aria-labelledby={ariaLabelledby}
+        className={className}
+        density={density}
+        responsive={responsive}
+        stackBreakpoint={stackBreakpoint}
+        striped={striped}
+        variant={variant}
+      >
+        {caption != null ? <TableCaption hidden={captionHidden}>{caption}</TableCaption> : null}
+
+        <TableHeader>
+          {table.getHeaderGroups().map(headerGroup => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map(header => {
+                const canSort = enableSorting && header.column.getCanSort();
+                const sorted = header.column.getIsSorted();
+                const align = header.column.columnDef.meta?.align ?? 'left';
+                const scope = header.colSpan > 1 ? 'colgroup' : 'col';
+
+                // A placeholder header exists only to keep grouped columns
+                // aligned (e.g. the top-left corner above an ungrouped column).
+                // Render it as an empty, hidden cell so it doesn't register as
+                // an empty table header for assistive tech.
+                if (header.isPlaceholder) {
+                  return (
+                    <td
+                      key={header.id}
+                      aria-hidden="true"
+                      className="bg-muted"
+                      colSpan={header.colSpan}
+                    />
+                  );
+                }
+
+                return (
+                  <TableHead
+                    key={header.id}
+                    aria-sort={
+                      !canSort
+                        ? undefined
+                        : sorted === 'asc'
+                          ? 'ascending'
+                          : sorted === 'desc'
+                            ? 'descending'
+                            : 'none'
+                    }
+                    className={alignClass[align]}
+                    colSpan={header.colSpan}
+                    scope={scope}
+                  >
+                    {canSort ? (
+                      <button
+                        className={cn(
+                          'inline-flex w-full items-center font-bold',
+                          alignJustify[align],
+                          styles.focusRingVisible,
+                        )}
+                        type="button"
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                        <SortIcon state={sorted} />
+                      </button>
+                    ) : (
+                      flexRender(header.column.columnDef.header, header.getContext())
+                    )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell className="text-center text-muted-foreground" colSpan={leafColumnCount}>
+                {emptyState}
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map(row => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map(cell => {
+                  const isRowHeader = cell.column.columnDef.meta?.isRowHeader;
+                  const align = cell.column.columnDef.meta?.align ?? 'left';
+                  const value = flexRender(cell.column.columnDef.cell, cell.getContext());
+                  const content =
+                    responsive === 'stack' ? (
+                      <>
+                        <span
+                          className={cn(
+                            'vero-table-stacked-label mr-4 font-bold text-foreground',
+                            tableStackLabelVisibility[stackBreakpoint],
+                          )}
+                        >
+                          {getStackLabel(cell.column)}
+                        </span>
+                        <span className="vero-table-cell-value">{value}</span>
+                      </>
+                    ) : (
+                      value
+                    );
+
+                  return isRowHeader ? (
+                    <TableHead key={cell.id} className={alignClass[align]} scope="row">
+                      {content}
+                    </TableHead>
+                  ) : (
+                    <TableCell key={cell.id} className={alignClass[align]}>
+                      {content}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+
+        {footer != null ? (
+          <TableFooter>
+            <TableRow>
+              <TableCell colSpan={leafColumnCount}>{footer}</TableCell>
+            </TableRow>
+          </TableFooter>
+        ) : null}
+      </TableRoot>
+
+      <div aria-live="polite" className="sr-only" role="status">
+        {announcement}
+      </div>
+    </>
+  );
+}
+
+const TableBase = React.forwardRef(TableInner);
+TableBase.displayName = 'Table';
+
+// forwardRef erases the generic, so re-assert it (same pattern as Autocomplete).
+const Table = TableBase as unknown as <TData>(
+  props: TableProps<TData> & { ref?: React.ForwardedRef<HTMLTableElement> },
+) => React.ReactElement;
+
+export { Table };

--- a/src/components/Table/src/TableRoot.test.tsx
+++ b/src/components/Table/src/TableRoot.test.tsx
@@ -1,0 +1,57 @@
+import { expectNoViolations } from '@/test/utils';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { TableRootColumnGroups } from '../demos/TableRootColumnGroups';
+import { TableRootBasic } from '../demos/TableRootBasic';
+import { TableRootRowGroups } from '../demos/TableRootRowGroups';
+import { TableRootStyleVariants } from '../demos/TableRootStyleVariants';
+
+describe('TableRoot (primitives)', () => {
+  describe('Accessibility', () => {
+    it('has no violations for a basic table', async () => {
+      const { container } = render(<TableRootBasic />);
+      expectNoViolations(await axe(container));
+    });
+
+    it('has no violations with grouped column headers', async () => {
+      const { container } = render(<TableRootColumnGroups />);
+      expectNoViolations(await axe(container));
+    });
+
+    it('has no violations with row-group sections', async () => {
+      const { container } = render(<TableRootRowGroups />);
+      expectNoViolations(await axe(container));
+    });
+
+    it('has no violations across style variants', async () => {
+      const { container } = render(<TableRootStyleVariants />);
+      expectNoViolations(await axe(container));
+    });
+  });
+
+  it('names the table with its caption', () => {
+    render(<TableRootBasic />);
+    expect(screen.getByRole('table', { name: 'Quarterly revenue' })).toBeInTheDocument();
+  });
+
+  it('renders column headers with scope="col"', () => {
+    render(<TableRootBasic />);
+    const quarter = screen.getByRole('columnheader', { name: 'Quarter' });
+    expect(quarter).toHaveAttribute('scope', 'col');
+  });
+
+  it('renders row headers with scope="row"', () => {
+    render(<TableRootBasic />);
+    const q1 = screen.getByRole('rowheader', { name: 'Q1' });
+    expect(q1.tagName).toBe('TH');
+    expect(q1).toHaveAttribute('scope', 'row');
+  });
+
+  it('uses scope="colgroup" on spanning group headers', () => {
+    render(<TableRootColumnGroups />);
+    const firstHalf = screen.getByRole('columnheader', { name: 'First half' });
+    expect(firstHalf).toHaveAttribute('scope', 'colgroup');
+    expect(firstHalf).toHaveAttribute('colspan', '2');
+  });
+});

--- a/src/components/Table/src/TableRoot.tsx
+++ b/src/components/Table/src/TableRoot.tsx
@@ -1,0 +1,167 @@
+import { styles } from '@/lib/styles';
+import { cn } from '@/lib/utils';
+import * as React from 'react';
+import { tableStackVariants, tableVariants } from '../constants';
+import type {
+  TableCaptionProps,
+  TableCellProps,
+  TableHeadProps,
+  TableRootProps,
+  TableRowProps,
+  TableSectionProps,
+} from '../types';
+
+/**
+ * Tracks whether an element's content overflows horizontally, so the scroll
+ * region only becomes a focusable, named region when it is actually
+ * scrollable — avoiding a phantom tab stop on tables that fit.
+ */
+function useHorizontalOverflow(ref: React.RefObject<HTMLElement>) {
+  const [overflowing, setOverflowing] = React.useState(false);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const measure = () => setOverflowing(el.scrollWidth > el.clientWidth);
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return overflowing;
+}
+
+const TableRoot = React.forwardRef<HTMLTableElement, TableRootProps>(
+  (
+    {
+      className,
+      variant,
+      striped,
+      density,
+      responsive = 'scroll',
+      stackBreakpoint = 'md',
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const scrollRef = React.useRef<HTMLDivElement>(null);
+    const overflowing = useHorizontalOverflow(scrollRef);
+
+    // aria-label / aria-labelledby name the <table> itself (its natural
+    // accessible name, alongside or instead of a <caption>).
+    const ariaLabel = props['aria-label'];
+    const ariaLabelledby = props['aria-labelledby'];
+
+    const table = (
+      <table
+        ref={ref}
+        className={cn(
+          tableVariants({ variant, striped, density }),
+          responsive === 'stack' && tableStackVariants[stackBreakpoint],
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </table>
+    );
+
+    if (responsive !== 'scroll') return table;
+
+    // Only expose the wrapper as a focusable, named region when the content
+    // actually overflows. A region needs an accessible name; when the table is
+    // named only by its caption, fall back to a plain (still keyboard-
+    // scrollable) container so we never emit an unnamed region.
+    const hasName = Boolean(ariaLabel || ariaLabelledby);
+    const regionProps = overflowing
+      ? hasName
+        ? {
+            role: 'region',
+            tabIndex: 0,
+            'aria-label': ariaLabel,
+            'aria-labelledby': ariaLabelledby,
+          }
+        : { tabIndex: 0 }
+      : {};
+
+    return (
+      <div
+        ref={scrollRef}
+        className={cn('vero-table-scroll overflow-x-auto', overflowing && styles.focusRingVisible)}
+        {...regionProps}
+      >
+        {table}
+      </div>
+    );
+  },
+);
+TableRoot.displayName = 'TableRoot';
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, TableCaptionProps>(
+  ({ className, hidden = false, ...props }, ref) => (
+    <caption
+      ref={ref}
+      className={cn('vero-table-caption', hidden && 'sr-only', className)}
+      {...props}
+    />
+  ),
+);
+TableCaption.displayName = 'TableCaption';
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, TableSectionProps>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn('vero-table-header', className)} {...props} />
+  ),
+);
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, TableSectionProps>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn('vero-table-body', className)} {...props} />
+  ),
+);
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, TableSectionProps>(
+  ({ className, ...props }, ref) => (
+    <tfoot ref={ref} className={cn('vero-table-footer font-bold', className)} {...props} />
+  ),
+);
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
+  ({ className, ...props }, ref) => (
+    <tr ref={ref} className={cn('vero-table-row', className)} {...props} />
+  ),
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
+  ({ className, scope = 'col', ...props }, ref) => (
+    <th ref={ref} className={cn('vero-table-head', className)} scope={scope} {...props} />
+  ),
+);
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn('vero-table-cell', className)} {...props} />
+  ),
+);
+TableCell.displayName = 'TableCell';
+
+export {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/src/components/Table/stories/Table.stories.tsx
+++ b/src/components/Table/stories/Table.stories.tsx
@@ -17,7 +17,7 @@ import { Table } from '../src/Table';
 const meta = {
   title: 'Data & Display/Table',
   component: Table,
-  tags: ['autodocs'],
+  tags: ['!dev'], // Internal — not ready for public API; hidden from the sidebar.
   parameters: {
     docs: {
       description: {

--- a/src/components/Table/stories/Table.stories.tsx
+++ b/src/components/Table/stories/Table.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TableColumnGroups } from '../demos/TableColumnGroups';
+import sourceColumnGroups from '../demos/TableColumnGroups.tsx?raw';
+import { TableDefault } from '../demos/TableDefault';
+import sourceDefault from '../demos/TableDefault.tsx?raw';
+import { TableEmpty } from '../demos/TableEmpty';
+import sourceEmpty from '../demos/TableEmpty.tsx?raw';
+import { TableScrollable } from '../demos/TableScrollable';
+import sourceScrollable from '../demos/TableScrollable.tsx?raw';
+import { TableSortable } from '../demos/TableSortable';
+import sourceSortable from '../demos/TableSortable.tsx?raw';
+import { TableStacked } from '../demos/TableStacked';
+import sourceStacked from '../demos/TableStacked.tsx?raw';
+import { people, personColumns } from '../demos/sampleData';
+import { Table } from '../src/Table';
+
+const meta = {
+  title: 'Data & Display/Table',
+  component: Table,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Config-driven table built on TanStack Table. Pass `data` and `columns` and it ' +
+          'renders through the accessible `TableRoot` primitives — with column grouping, row ' +
+          'headers (`meta.isRowHeader`), sorting (`aria-sort` + live announcements), and ' +
+          'scroll / stacked responsive behavior.',
+      },
+    },
+  },
+  // The stories below render self-contained demos; these satisfy the required
+  // props on the shared meta type.
+  args: { data: [], columns: [] },
+  argTypes: {
+    enableSorting: { control: 'boolean', description: 'Enable column sorting.' },
+    variant: { control: 'radio', options: ['bordered', 'borderless'] },
+    striped: { control: 'boolean' },
+    density: { control: 'radio', options: ['default', 'compact'] },
+    responsive: { control: 'radio', options: ['scroll', 'stack', 'none'] },
+    stackBreakpoint: { control: 'radio', options: ['sm', 'md', 'lg'] },
+  },
+} satisfies Meta<typeof Table>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Static example stories show copy-pasteable source and don't consume args, so
+// hide the (non-functional) controls panel on them. Use Playground to explore
+// the props interactively.
+const withSource = (code: string) => ({
+  controls: { disable: true },
+  docs: { source: { code, language: 'tsx' } },
+});
+
+/**
+ * Interactive example — toggle `enableSorting`, `striped`, `variant`,
+ * `density`, and `responsive` in the Controls panel to see them applied live.
+ */
+export const Playground: Story = {
+  args: {
+    caption: 'Team roster',
+    enableSorting: false,
+    variant: 'bordered',
+    striped: false,
+    density: 'default',
+    responsive: 'scroll',
+    stackBreakpoint: 'md',
+  },
+  render: args => <Table {...args} columns={personColumns} data={people} />,
+};
+
+/** Pass `data` + `columns`; the `name` column is the row header. */
+export const Default: Story = {
+  render: () => <TableDefault />,
+  parameters: withSource(sourceDefault),
+};
+
+/**
+ * Sortable columns. Headers are buttons; the `<th>` carries `aria-sort` and
+ * changes are announced to screen readers.
+ */
+export const Sortable: Story = {
+  render: () => <TableSortable />,
+  parameters: withSource(sourceSortable),
+};
+
+/** Nested column definitions produce multi-level headers. */
+export const ColumnGroups: Story = {
+  render: () => <TableColumnGroups />,
+  parameters: withSource(sourceColumnGroups),
+};
+
+/**
+ * Scrollable (default) responsive mode: a keyboard-focusable, labeled scroll
+ * region appears when the table overflows its container.
+ */
+export const Scrollable: Story = {
+  render: () => <TableScrollable />,
+  parameters: withSource(sourceScrollable),
+};
+
+/**
+ * Stacked responsive mode: rows become labeled cards below the breakpoint.
+ * Resize the preview narrow to see it reflow.
+ */
+export const Stacked: Story = {
+  render: () => <TableStacked />,
+  parameters: withSource(sourceStacked),
+};
+
+/** Empty state shown when there are no rows. */
+export const Empty: Story = {
+  render: () => <TableEmpty />,
+  parameters: withSource(sourceEmpty),
+};

--- a/src/components/Table/stories/TableRoot.stories.tsx
+++ b/src/components/Table/stories/TableRoot.stories.tsx
@@ -20,7 +20,7 @@ import {
 const meta = {
   title: 'Data & Display/Table/Primitives',
   component: TableRoot,
-  tags: ['autodocs'],
+  tags: ['!dev'], // Internal — not ready for public API; hidden from the sidebar.
   parameters: {
     docs: {
       description: {

--- a/src/components/Table/stories/TableRoot.stories.tsx
+++ b/src/components/Table/stories/TableRoot.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TableRootColumnGroups } from '../demos/TableRootColumnGroups';
+import sourceColumnGroups from '../demos/TableRootColumnGroups.tsx?raw';
+import { TableRootBasic } from '../demos/TableRootBasic';
+import sourcePrimitive from '../demos/TableRootBasic.tsx?raw';
+import { TableRootRowGroups } from '../demos/TableRootRowGroups';
+import sourceRowGroups from '../demos/TableRootRowGroups.tsx?raw';
+import { TableRootStyleVariants } from '../demos/TableRootStyleVariants';
+import sourceStyleVariants from '../demos/TableRootStyleVariants.tsx?raw';
+import {
+  TableRoot,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../src/TableRoot';
+
+const meta = {
+  title: 'Data & Display/Table/Primitives',
+  component: TableRoot,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Accessible, USWDS-styled table primitives. Compose `TableRoot`, `TableCaption`, ' +
+          '`TableHeader`, `TableBody`, `TableFooter`, `TableRow`, `TableHead`, and `TableCell` ' +
+          'directly for small or bespoke tables. For data-driven tables, see `Table`, which ' +
+          'renders through these same primitives.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['bordered', 'borderless'],
+      description: 'Grid line style.',
+    },
+    striped: { control: 'boolean', description: 'Alternate row background.' },
+    density: {
+      control: 'radio',
+      options: ['default', 'compact'],
+      description: 'Cell padding density.',
+    },
+    responsive: {
+      control: 'radio',
+      options: ['scroll', 'stack', 'none'],
+      description: 'How the table adapts to narrow viewports.',
+    },
+  },
+} satisfies Meta<typeof TableRoot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Static example stories show copy-pasteable source and don't consume args, so
+// hide the (non-functional) controls panel on them. Use Playground to explore
+// the props interactively.
+const withSource = (code: string) => ({
+  controls: { disable: true },
+  docs: { source: { code, language: 'tsx' } },
+});
+
+/**
+ * Interactive example — change `variant`, `striped`, `density`, and
+ * `responsive` in the Controls panel to see them applied live.
+ */
+export const Playground: Story = {
+  args: { variant: 'bordered', striped: false, density: 'default', responsive: 'none' },
+  render: args => (
+    <TableRoot {...args} aria-label="Fruit inventory">
+      <TableCaption>Fruit inventory</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead scope="col">Fruit</TableHead>
+          <TableHead className="text-right" scope="col">
+            Qty
+          </TableHead>
+          <TableHead className="text-right" scope="col">
+            Price
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableHead scope="row">Apples</TableHead>
+          <TableCell className="text-right">12</TableCell>
+          <TableCell className="text-right">$0.50</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableHead scope="row">Bananas</TableHead>
+          <TableCell className="text-right">8</TableCell>
+          <TableCell className="text-right">$0.25</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableHead scope="row">Cherries</TableHead>
+          <TableCell className="text-right">30</TableCell>
+          <TableCell className="text-right">$0.10</TableCell>
+        </TableRow>
+      </TableBody>
+    </TableRoot>
+  ),
+};
+
+/**
+ * A basic table composed from the primitives, with a `<caption>`, column
+ * headers (`scope="col"`), and a row header per row (`scope="row"`).
+ */
+export const Default: Story = {
+  render: () => <TableRootBasic />,
+  parameters: withSource(sourcePrimitive),
+};
+
+/**
+ * Multi-level column headers using `colSpan` + `scope="colgroup"` for the group
+ * headers and `scope="col"` for the leaf headers.
+ */
+export const ColumnGroups: Story = {
+  render: () => <TableRootColumnGroups />,
+  parameters: withSource(sourceColumnGroups),
+};
+
+/**
+ * Visual row-group sections: multiple `<TableBody>` blocks, each introduced by
+ * a spanning group header.
+ */
+export const RowGroupSections: Story = {
+  render: () => <TableRootRowGroups />,
+  parameters: withSource(sourceRowGroups),
+};
+
+/**
+ * The `variant` (bordered / borderless), `striped`, and `density` style
+ * options.
+ */
+export const StyleVariants: Story = {
+  render: () => <TableRootStyleVariants />,
+  parameters: withSource(sourceStyleVariants),
+};

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -1,0 +1,150 @@
+import type { VariantProps } from 'class-variance-authority';
+import type { ColumnDef, OnChangeFn, RowData, SortingState } from '@tanstack/react-table';
+import type {
+  HTMLAttributes,
+  ReactNode,
+  TableHTMLAttributes,
+  TdHTMLAttributes,
+  ThHTMLAttributes,
+} from 'react';
+import type { tableVariants } from './constants';
+
+/**
+ * Extra per-column configuration understood by {@link Table}. Set on a
+ * column via `ColumnDef.meta`, e.g. `{ meta: { isRowHeader: true } }`.
+ *
+ * This augments TanStack Table's own `ColumnMeta` interface so the fields are
+ * available wherever a `ColumnDef` is typed.
+ */
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    /**
+     * When true, this column's cells render as `<th scope="row">` instead of
+     * `<td>`, making them row headers for assistive technology. Designate
+     * exactly one column per table as the row header for the best experience.
+     */
+    isRowHeader?: boolean;
+    /**
+     * Horizontal alignment of the column's header and cells.
+     * @default 'left'
+     */
+    align?: 'left' | 'center' | 'right';
+    /**
+     * Label used to prefix this column's cells when the table is displayed in
+     * stacked (card) mode. Defaults to the column's header text when it is a
+     * plain string, otherwise the column id.
+     */
+    stackedLabel?: string;
+  }
+}
+
+/** Responsive behavior for a table on narrow viewports. */
+export type TableResponsive = 'scroll' | 'stack' | 'none';
+
+/** Breakpoint at which a stacked table returns to a normal grid layout. */
+export type TableStackBreakpoint = 'sm' | 'md' | 'lg';
+
+type TableVariantProps = VariantProps<typeof tableVariants>;
+
+export interface TableRootProps
+  extends Omit<TableHTMLAttributes<HTMLTableElement>, 'aria-label' | 'aria-labelledby'>,
+    TableVariantProps {
+  /**
+   * How the table adapts to narrow viewports.
+   * - `scroll` (default): wrap the table in a keyboard-focusable horizontal
+   *   scroll region.
+   * - `stack`: collapse rows into stacked cards below `stackBreakpoint`.
+   * - `none`: no responsive treatment.
+   * @default 'scroll'
+   */
+  responsive?: TableResponsive;
+  /**
+   * Breakpoint at which a `stack` table returns to a normal grid layout.
+   * @default 'md'
+   */
+  stackBreakpoint?: TableStackBreakpoint;
+  /**
+   * Accessible name for the scroll region (used when `responsive="scroll"`).
+   * A table should always have an accessible name via a `<caption>`; provide
+   * this so the scroll region is also named for screen-reader users.
+   */
+  'aria-label'?: string;
+  /** Id of an element that labels the scroll region. */
+  'aria-labelledby'?: string;
+}
+
+export type TableCaptionProps = HTMLAttributes<HTMLTableCaptionElement> & {
+  /**
+   * Visually hide the caption while keeping it available to assistive
+   * technology, so the table still has an accessible name without a visible
+   * title.
+   * @default false
+   */
+  hidden?: boolean;
+};
+
+export type TableSectionProps = HTMLAttributes<HTMLTableSectionElement>;
+export type TableRowProps = HTMLAttributes<HTMLTableRowElement>;
+
+export interface TableHeadProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  /**
+   * The header's scope. Use `col` for column headers, `row` for row headers,
+   * and `colgroup`/`rowgroup` for headers that span a group.
+   * @default 'col'
+   */
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+}
+
+export type TableCellProps = TdHTMLAttributes<HTMLTableCellElement>;
+
+export interface TableProps<TData> extends TableVariantProps {
+  /** The rows to render. */
+  data: TData[];
+  /** TanStack Table column definitions. */
+  columns: ColumnDef<TData, unknown>[];
+  /**
+   * The table's caption / accessible name. Strongly recommended — every table
+   * should have one.
+   */
+  caption?: ReactNode;
+  /** Visually hide the caption while keeping it available to screen readers. */
+  captionHidden?: boolean;
+  /**
+   * Explicit accessible name, used when {@link caption} is not provided (for
+   * example when a visible heading already describes the table).
+   */
+  'aria-label'?: string;
+  /** Id of an element that labels the table. */
+  'aria-labelledby'?: string;
+  /**
+   * Enable column sorting. Individual columns can opt out with
+   * `enableSorting: false` in their `ColumnDef`.
+   * @default false
+   */
+  enableSorting?: boolean;
+  /** Initial (uncontrolled) sorting state. */
+  initialSorting?: SortingState;
+  /** Controlled sorting state. */
+  sorting?: SortingState;
+  /** Called when the sorting state changes (controlled mode). */
+  onSortingChange?: OnChangeFn<SortingState>;
+  /**
+   * How the table adapts to narrow viewports.
+   * @default 'scroll'
+   */
+  responsive?: TableResponsive;
+  /**
+   * Breakpoint at which a `stack` table returns to a normal grid layout.
+   * @default 'md'
+   */
+  stackBreakpoint?: TableStackBreakpoint;
+  /** Content shown when `data` is empty. */
+  emptyState?: ReactNode;
+  /** Optional footer content rendered in a `<tfoot>`. */
+  footer?: ReactNode;
+  /** Returns a stable id for a row (forwarded to TanStack `getRowId`). */
+  getRowId?: (row: TData, index: number) => string;
+  /** Additional class names for the `<table>` element. */
+  className?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export * from './components/Select';
 export * from './components/StepIndicator';
 export * from './components/Switch';
 export * from './components/SwitchGroup';
+export * from './components/Table';
 export * from './components/Tabs';
 // Internal — not ready for public API. Hidden from Storybook via tags: ['!dev'].
 // export * from './components/TagInput';

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ export * from './components/Select';
 export * from './components/StepIndicator';
 export * from './components/Switch';
 export * from './components/SwitchGroup';
-export * from './components/Table';
+// Internal — not ready for public API. Hidden from Storybook via tags: ['!dev'].
+// export * from './components/Table';
 export * from './components/Tabs';
 // Internal — not ready for public API. Hidden from Storybook via tags: ['!dev'].
 // export * from './components/TagInput';


### PR DESCRIPTION
## Summary

Adds a new 508-compliant **Table** component to `@capitaltg/vero`, styled like the [USWDS table](https://designsystem.digital.gov/components/table/) and powered by [TanStack Table](https://tanstack.com/table). It ships a **hybrid API**:

- **`TableRoot` + primitives** (`TableHeader`, `TableBody`, `TableFooter`, `TableRow`, `TableHead`, `TableCell`, `TableCaption`) — compose small or bespoke tables with native `<table>` semantics.
- **`Table<T>`** — config-driven (`data` + `columns`) built on `useReactTable`, rendering through the same primitives via `flexRender`.

## v1 features

- Multi-level **column grouping** (auto `colSpan` + `scope="colgroup"`)
- **Row headers** via `meta.isRowHeader` → `<th scope="row">`
- **Column sorting** — real `<button>` headers, `aria-sort`, and polite live-region announcements
- **Visual row-group sections** (multiple `<tbody>`)
- **Responsive**: keyboard-focusable scroll region (default) + opt-in stacked/card mode
- **Style variants**: bordered / borderless / striped / compact, using theme-adaptive tokens (works in default, `.dark`, and `.theme-uswds`)

## Accessibility

Native `<table>` semantics (no ARIA grid), always-named tables via `<caption>`, correct `scope` throughout, sort announcements, and a scroll region that only becomes a focusable landmark when it actually overflows. Every state is covered by `vitest-axe`; sorting has interaction tests.

## Notes for reviewers

- New dependency: `@tanstack/react-table` (tree-shakeable; bundle is ~89 KB brotlied, within the 150 KB budget).
- Storybook: **Data & Display / Table** (config-driven) with a nested **Primitives** section; each layer has an interactive **Playground** plus static source demos.
- Stacked responsive mode trades grid semantics for the card layout below the breakpoint (standard responsive-table pattern) — a manual screen-reader pass is recommended before relying on it.
- `src/components/Table/PLAN.md` documents the design and the phased v2+ backlog (row selection, pagination, filtering, collapsible/aggregated grouping, etc.).

## Testing

- `npm test` — all green (19 new tests)
- `npm run type-check`, `npm run lint`, `npm run build`, `npm run size` — all pass