### PR TITLE
perf: externalize dependencies to slim the published bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.0.4",
+        "@radix-ui/react-compose-refs": "^1.1.2",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-primitive": "^2.1.0",
         "@radix-ui/react-radio-group": "^1.1.3",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/types/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "files": [
     "dist"
   ],
@@ -59,10 +61,12 @@
   "dependencies": {
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",
+    "@radix-ui/react-compose-refs": "^1.1.2",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-primitive": "^2.1.0",
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -142,11 +142,59 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "150 KB"
+      "limit": "50 KB",
+      "ignore": [
+        "@radix-ui/react-accordion",
+        "@radix-ui/react-checkbox",
+        "@radix-ui/react-compose-refs",
+        "@radix-ui/react-dialog",
+        "@radix-ui/react-dropdown-menu",
+        "@radix-ui/react-label",
+        "@radix-ui/react-popover",
+        "@radix-ui/react-primitive",
+        "@radix-ui/react-radio-group",
+        "@radix-ui/react-select",
+        "@radix-ui/react-slot",
+        "@radix-ui/react-switch",
+        "@radix-ui/react-tabs",
+        "@radix-ui/react-tooltip",
+        "@tanstack/react-table",
+        "class-variance-authority",
+        "clsx",
+        "cmdk",
+        "date-fns",
+        "lucide-react",
+        "react-day-picker",
+        "tailwind-merge"
+      ]
     },
     {
       "path": "dist/index.cjs",
-      "limit": "150 KB"
+      "limit": "50 KB",
+      "ignore": [
+        "@radix-ui/react-accordion",
+        "@radix-ui/react-checkbox",
+        "@radix-ui/react-compose-refs",
+        "@radix-ui/react-dialog",
+        "@radix-ui/react-dropdown-menu",
+        "@radix-ui/react-label",
+        "@radix-ui/react-popover",
+        "@radix-ui/react-primitive",
+        "@radix-ui/react-radio-group",
+        "@radix-ui/react-select",
+        "@radix-ui/react-slot",
+        "@radix-ui/react-switch",
+        "@radix-ui/react-tabs",
+        "@radix-ui/react-tooltip",
+        "@tanstack/react-table",
+        "class-variance-authority",
+        "clsx",
+        "cmdk",
+        "date-fns",
+        "lucide-react",
+        "react-day-picker",
+        "tailwind-merge"
+      ]
     },
     {
       "path": "dist/index.css",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,17 +41,16 @@ export default defineConfig({
           hook: 'writeBundle', // Make sure this is done after the build
         }),
       ],
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
-      output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          'react/jsx-runtime': 'jsxRuntime',
-        },
-      },
+      // Externalize every bare (node_modules) import so consumers install,
+      // dedupe, and tree-shake them — instead of inlining ~400 kB of Radix /
+      // lucide / date-fns / etc. into the library bundle. Relative imports, the
+      // `@/` alias, and resolved absolute paths (our own source + CSS) stay in.
+      external: id => !id.startsWith('.') && !path.isAbsolute(id) && !id.startsWith('@/'),
     },
     cssCodeSplit: true,
-    sourcemap: true,
+    // Don't ship sourcemaps in the published package (devtools-only, and they
+    // dominate the tarball size).
+    sourcemap: false,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

The library build externalized only React, so every other dependency (all `@radix-ui/*`, `lucide-react`, `date-fns`, `react-day-picker`, `cmdk`, …) was **inlined into `dist/index.js`**. That bloated the payload and forced consumers to ship duplicate copies of shared deps with no dedupe or tree-shaking.

## Changes

- **Externalize all bare (node_modules) imports** in the Vite lib build — consumers install, dedupe, and tree-shake them via their own bundler.
- **Declare `@radix-ui/react-compose-refs` and `@radix-ui/react-primitive`** as direct dependencies (previously imported but only present transitively), so externalizing them can't break consumers.
- **`"sideEffects": ["**/*.css"]`** instead of `false` — keeps the CSS import intact while still tree-shaking unused component exports.
- **Stop publishing sourcemaps** (`sourcemap: false`) to shrink the package tarball.

## Impact

| | raw | gzip | brotli (import-all) |
|---|---|---|---|
| `dist/index.js` before | 500.8 kB | 122.6 kB | 88.8 kB |
| `dist/index.js` after | **97.5 kB** | **20.7 kB** | **76.7 kB** |

The library's own JS shrinks ~83%; the deps now live in the consumer's graph where they dedupe and tree-shake. Consumers importing a subset of components pay far less than before.

## Considered but not adopted

`output.preserveModules` (per-file output) was evaluated and **rejected**: every component barrel is named `index.ts`, so the preserved filenames collide (`index2.js`, `index3.js`, …), and it breaks the `dist/index.css` output contract. Making it clean would require replacing Vite's `lib` helper with a hand-rolled rollup output + CSS pipeline — disproportionate risk for a marginal gain, since `sideEffects`-based tree-shaking of the single bundle already delivers the per-component win.

## Testing

- `npm test` — 172 passing
- `npm run type-check`, `npm run build`, `npm run size` — all pass; every exports-contract file (`index.js`, `index.cjs`, `index.css`, `preflight.css`, `tailwind.config.js`, `types/index.d.ts`) verified present
- Confirmed no dependency implementation is inlined (0 occurrences of Radix internals in `dist/index.js`)